### PR TITLE
specific getindex for single vs. slice

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -81,8 +81,8 @@ get_periodic(sys::AbstractSystem) = [isa(bc, Periodic) for bc in get_boundary_co
 # Note: Can't use ndims, because that is ndims(sys) == 1 (because of AbstractVector interface)
 n_dimensions(sys::AbstractSystem) = length(get_boundary_conditions(sys))
 
-Base.getindex(::AbstractSystem{AT}, ::Int)::AT  = error("Implement me")
-Base.getindex(::AbstractSystem, ::AbstractArray)::AbstractSystem  = error("Implement me")
+Base.getindex(::AbstractSystem{AT}, I)::AT  = error("Implement me") # for single indices
+Base.getindex(::AbstractSystem, ::T)::AbstractSystem where {T<:Union{AbstractArray, Colon}} = error("Implement me") # for slicing
 Base.size(::AbstractSystem)             = error("Implement me")
 Base.setindex!(::AbstractSystem, ::Int) = error("AbstractSystem objects are not mutable.")
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -81,7 +81,8 @@ get_periodic(sys::AbstractSystem) = [isa(bc, Periodic) for bc in get_boundary_co
 # Note: Can't use ndims, because that is ndims(sys) == 1 (because of AbstractVector interface)
 n_dimensions(sys::AbstractSystem) = length(get_boundary_conditions(sys))
 
-Base.getindex(::AbstractSystem, ::Int)  = error("Implement me")
+Base.getindex(::AbstractSystem{AT}, ::Int)::AT  = error("Implement me")
+Base.getindex(::AbstractSystem, ::AbstractArray)::AbstractSystem  = error("Implement me")
 Base.size(::AbstractSystem)             = error("Implement me")
 Base.setindex!(::AbstractSystem, ::Int) = error("AbstractSystem objects are not mutable.")
 


### PR DESCRIPTION
Thought it might make sense to explicitly include both of these options, per our discussion last Friday. I think we should also split out the sample implementations and rename the current `implementation_simple` to `implementation_simple_aos` or something like that and then add an analogous SoA version, which would need to explicitly dispatch these separately.

Not sure this actually makes sense to merge as-is though, since currently I think it would also break the existing `implementation_simple`, and we may want to have things set up for that case to be able to "just work." If so, I think we'd just need to define the slice dispatch to be the standard Julia behavior.

So yeah, this is more to start a conversation I suppose? But getting it to a non-draft state should be pretty simple once we decide what we want the behavior to be.