### PR TITLE
`AbstractParticle` takes a type parameter `<:AbstractElement`

### DIFF
--- a/src/implementation_simple.jl
+++ b/src/implementation_simple.jl
@@ -28,5 +28,3 @@ get_boundary_conditions(sys::SimpleSystem) = sys.boundary_conditions
 Base.size(sys::SimpleSystem) = size(sys.particles)
 Base.length(sys::SimpleSystem) = length(sys.particles)
 Base.getindex(sys::SimpleSystem, i::Int) = getindex(sys.particles, i)
-
-SimpleAtomicSystem{D} = SimpleSystem{D, ChemicalElement, SimpleAtom{D}}

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -3,7 +3,7 @@ using UnitfulAtomic
 using PeriodicTable
 using StaticArrays
 
-export AbstractElement, AbstractParticle, AbstractAtom, AbstractSystem
+export AbstractElement, AbstractParticle, AbstractAtom, AbstractSystem, AbstractAtomicSystem
 export ChemicalElement
 export BoundaryCondition, DirichletZero, Periodic
 export get_atomic_mass, get_atomic_number, get_atomic_symbol,
@@ -74,7 +74,7 @@ struct Periodic      <: BoundaryCondition end  # Periodic BCs
 # The system type
 #     Again readonly.
 #
-abstract type AbstractSystem{D<:Unsigned, ET<:AbstractElement, AT<:AbstractParticle{ET}} end
+abstract type AbstractSystem{D, ET<:AbstractElement, AT<:AbstractParticle{ET}} end
 (get_box(::AbstractSystem{D,ET,AT})::SVector{D, SVector{D, <:Unitful.Length}}) where {D,ET,AT} = error("Implement me")
 (get_boundary_conditions(::AbstractSystem{D,ET,AT})::SVector{D,BoundaryCondition}) where {D,ET,AT} = error("Implement me")
 get_periodic(sys::AbstractSystem) = [isa(bc, Periodic) for bc in get_boundary_conditions(sys)]
@@ -102,11 +102,12 @@ get_element(sys::AbstractSystem)  = get_element.(sys)
 #
 # Extra stuff only for Systems composed of atoms
 #
-get_atomic_symbol(sys::AbstractSystem{<: AbstractAtom}) = get_atomic_symbol.(sys)
-get_atomic_number(sys::AbstractSystem{<: AbstractAtom}) = get_atomic_number.(sys)
-get_atomic_mass(sys::AbstractSystem{<: AbstractAtom})   = get_atomic_mass.(sys)
-get_atomic_property(sys::AbstractSystem{<: AbstractAtom}, property::Symbol)::Vector{Any} = get_atomic_property.(sys, property)
-atomic_propertiesnames(sys::AbstractSystem{<: AbstractAtom}) = unique(sort(atomic_propertynames.(sys)))
+AbstractAtomicSystem{D,AT<:AbstractAtom} = AbstractSystem{D,ChemicalElement,AT}
+get_atomic_symbol(sys::AbstractAtomicSystem) = get_atomic_symbol.(sys)
+get_atomic_number(sys::AbstractAtomicSystem) = get_atomic_number.(sys)
+get_atomic_mass(sys::AbstractAtomicSystem)   = get_atomic_mass.(sys)
+get_atomic_property(sys::AbstractAtomicSystem, property::Symbol)::Vector{Any} = get_atomic_property.(sys, property)
+atomic_propertiesnames(sys::AbstractAtomicSystem) = unique(sort(atomic_propertynames.(sys)))
 
 # Just to make testing a little easier for now
 function Base.show(io::IO, ::MIME"text/plain", part::AbstractParticle)


### PR DESCRIPTION
Per discussion today. First commit just adds the type parameter. Second commit felt related enough to put here, and does two main things:
1. renames our `Element` to `ChemicalElement` to fix namespace conflict with `PeriodicTable.Element`
2. redefines `AbstractAtom` to be `<:AbstractParticle{ChemicalElement}`. 

I tested this out by setting up a dummy subtype locally and it seems to work fine.