### PR TITLE
Minor fixes, convenience constructors

### DIFF
--- a/sandbox/load_using_ase.jl
+++ b/sandbox/load_using_ase.jl
@@ -9,7 +9,7 @@ function ase_to_simple(atoms)
     boundary_conditions = [(isperiodic ? Periodic() : DirichletZero()) for isperiodic in atoms.pbc]
     simple_atoms = [SimpleAtom(atom.position * 1u"Å", Symbol(atom.symbol))
                     for atom in atoms]
-    SimpleAtomicSystem{3}(box, boundary_conditions, simple_atoms)
+    SimpleSystem(box, boundary_conditions, simple_atoms)
 end
 
 load_using_ase(filename; kwargs...) = ase_to_simple(pyimport("ase.io").read(filename; kwargs...))

--- a/sandbox/load_using_ase.jl
+++ b/sandbox/load_using_ase.jl
@@ -7,9 +7,12 @@ using AtomsBase
 function ase_to_simple(atoms)
     box = [vec * 1u"Å" for vec in atoms.cell]  # Check this picks up the vectors in the right order
     boundary_conditions = [(isperiodic ? Periodic() : DirichletZero()) for isperiodic in atoms.pbc]
-    simple_atoms = [SimpleAtom(atom.position * 1u"Å", Symbol(atom.symbol))
-                    for atom in atoms]
-    SimpleSystem(box, boundary_conditions, simple_atoms)
+
+    pos = atoms.positions * 1u"Å"
+    symbols = atoms.get_chemical_symbols()
+    simple_atoms = SimpleAtom.(eachrow(pos), Symbol.(symbols))
+
+    return SimpleSystem(box, boundary_conditions, simple_atoms)
 end
 
 load_using_ase(filename; kwargs...) = ase_to_simple(pyimport("ase.io").read(filename; kwargs...))

--- a/src/implementation_simple.jl
+++ b/src/implementation_simple.jl
@@ -2,13 +2,13 @@
 #
 using StaticArrays
 
-export SimpleAtom, SimpleSystem, SimpleAtomicSystem
+export SimpleAtom, SimpleSystem
 
 struct SimpleAtom{D, T<:Unitful.Length} <: AbstractAtom
     position::SVector{D, T}
     element::ChemicalElement
 end
-SimpleAtom(position, element)  = SimpleAtom{length(position)}(position, element)
+SimpleAtom(position, element)  = SimpleAtom{length(position), eltype(position)}(position, element)
 position(atom::SimpleAtom) = atom.position
 element(atom::SimpleAtom)  = atom.element
 
@@ -22,6 +22,16 @@ struct SimpleSystem{D, ET<:AbstractElement, AT<:AbstractParticle{ET}, T<:Unitful
     boundary_conditions::SVector{D, BoundaryCondition}
     particles::Vector{AT}
 end
+
+function SimpleSystem(box, boundary_conditions, particles)
+    D = length(box)
+    ET = typeof(element(first(particles)))
+    AT = eltype(particles)
+    T = eltype(first(box))
+
+    SimpleSystem{D, ET, AT, T}(box, boundary_conditions, particles)
+end
+
 bounding_box(sys::SimpleSystem) = sys.box
 boundary_conditions(sys::SimpleSystem) = sys.boundary_conditions
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -94,6 +94,7 @@ Base.length(::AbstractSystem)           = error("Implement me")
 Base.setindex!(::AbstractSystem, ::Int) = error("AbstractSystem objects are not mutable.")
 Base.firstindex(::AbstractSystem) = 1
 Base.lastindex(s::AbstractSystem) = length(s)
+Base.iterate(S::AbstractSystem, i::Int=1) = (1 <= i <= length(S)) ? (@inbounds S[i], i+1) : nothing
 
 # TODO Support similar, push, ...
 


### PR DESCRIPTION
Some small changes:

- Removed undefined export of SimpleAtomicSystem
- Added convenience constructor for SimpleSystem
- Fixed constructor of SimpleAtom
- Modified load_using_ase.jl to include these changes and improved it a bit.
- The show() function of AbstractSystem was not working as iterate(::AbstractSytem) was not defined, fixed it.