### PR TITLE
remove Base.show dispatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsBase"
 uuid = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 authors = ["JuliaMolSim community"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -101,16 +101,3 @@ Return a vector of species of every particle in the system `sys`. Return type sh
 """
 species(sys::AbstractSystem) = species.(sys)
 (species(sys::AbstractSystem{D,S}, index)::S) where {D,S} = species(sys[index])
-
-# Just to make testing a little easier for now
-function Base.show(io::IO, mime::MIME"text/plain", sys::AbstractSystem)
-    println(io, "$(string(nameof(typeof(sys)))):")
-    println(io, "    BCs:        ", boundary_conditions(sys))
-    println(io, "    Box:        ", bounding_box(sys))
-    println(io, "    Particles:  ")
-    for particle in sys
-        print("        ")
-        Base.show(io, mime, particle)
-        println(io)
-    end
-end


### PR DESCRIPTION
Having it there causes problems in downstream packages who have their own `show` methods but if they've only defined one of the `show` flavors and it gets invoked in REPL, it might fall back to this one, which is especially problematic if for any reason one of the interface functions it relies upon isn't dispatched...