### PR TITLE
Fix docs deployment

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          ssh: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
As described in https://github.com/JuliaMolSim/AtomsBase.jl/pull/41 the docs build is not triggering when TagBot runs.

I have added the appropriate repo secrets so this should solve the problem.