### PR TITLE
`show` for `FastSystem` and improved tests

### DIFF
--- a/src/fast_system.jl
+++ b/src/fast_system.jl
@@ -41,6 +41,11 @@ function FastSystem(particles, box, boundary_conditions)
                atomic_number.(particles), atomic_mass.(particles))
 end
 
+function Base.show(io::IO, system::FastSystem)
+    print(io, "FastSystem")
+    show_system(io, system)
+end
+
 bounding_box(sys::FastSystem)        = sys.box
 boundary_conditions(sys::FastSystem) = sys.boundary_conditions
 Base.length(sys::FastSystem)         = length(sys.positions)

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -4,11 +4,17 @@ using Test
 
 @testset "Printing atomic systems" begin
     at = Atom(:Si, zeros(3) * u"m", extradata=42)
-    println(at)
-
+    @test repr(at) == "Atom(Si, [0.0, 0.0, 0.0]u\"m\")"
+    
     atoms = [:Si => [0.0, -0.125, 0.0],
              :C  => [0.125, 0.0, 0.0]]
     box = [[10, 0.0, 0.0], [0.0, 5, 0.0], [0.0, 0.0, 7]]u"Å"
-    system = periodic_system(atoms, box; fractional=true)
-    println(system)
+
+    flexible_system = periodic_system(atoms, box; fractional=true)
+    @test repr(flexible_system) == """
+    FlexibleSystem(CSi, Periodic, box=[[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"Å")"""
+
+    fast_system = FastSystem(flexible_system)
+    @test repr(fast_system) == """
+    FastSystem(CSi, Periodic, box=[[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"Å")"""
 end


### PR DESCRIPTION
The tests for printing were not testing anything. I have used `repr` to test the `show` methods.