### PR TITLE
Another `FastSystem` constructor

### DIFF
--- a/src/fast_system.jl
+++ b/src/fast_system.jl
@@ -12,7 +12,17 @@ struct FastSystem{D, L <: Unitful.Length, M <: Unitful.Mass} <: AbstractSystem{D
     atomic_masses::Vector{M}
 end
 
-# Constructor to fetch the types
+# Constructor to fetch the types and numbers/masses
+function FastSystem(box, boundary_conditions, positions, atomic_symbols)
+    elements = element.(atomic_symbols)
+    atomic_numbers = getproperty.(elements, :number)
+    atomic_masses = getproperty.(elements, :atomic_mass)
+    FastSystem{length(box),eltype(eltype(positions)),eltype(atomic_masses)}(
+        box, boundary_conditions, positions, atomic_symbols, atomic_numbers, atomic_masses
+    )
+end
+
+# constructor to fetch the types where numbers/masses are explicitly provided
 function FastSystem(box, boundary_conditions, positions, atomic_symbols, atomic_numbers, atomic_masses)
     FastSystem{length(box),eltype(eltype(positions)),eltype(atomic_masses)}(
         box, boundary_conditions, positions, atomic_symbols, atomic_numbers, atomic_masses


### PR DESCRIPTION
I found myself wanting to be able to construct a `FastSystem` without needing to explicitly build the lists of atomic data when they could be inferred, so I added a constructor that will infer atomic numbers and masses if you only supply the symbols. We could also merge this into the original one by providing default values for the latter two arguments. I am completely fine changing this to that instead, i.e. removing the new one I added and instead modifying lines 15-20 to be something like:
```julia
# constructor to fetch the types where numbers/masses are explicitly provided
function FastSystem(box, boundary_conditions, positions, atomic_symbols, atomic_numbers=getproperty.(element.(atomic_symbols), :number), atomic_masses=getproperty.(element.(atomic_symbols), :atomic_mass))
    FastSystem{length(box),eltype(eltype(positions)),eltype(atomic_masses)}(
        box, boundary_conditions, positions, atomic_symbols, atomic_numbers, atomic_masses
    )
end
```
...but that's also a little clunky to read. 🤷‍♀️ 