### PR TITLE
Rename getkey to get and fix it

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsBase"
 uuid = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 authors = ["JuliaMolSim community"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -38,7 +38,7 @@ and implementations of standard functions accessing the properties of the specie
 currently
   - Geometric information: [`position`](@ref), [`velocity`](@ref), [`n_dimensions`](@ref)
   - Atomic information: [`atomic_symbol`](@ref), [`atomic_mass`](@ref), [`atomic_number`](@ref), [`element`](@ref)
-  - Atomic and system property accessors: `getindex`, `haskey`, `getkey`, `keys`, `pairs`
+  - Atomic and system property accessors: `getindex`, `haskey`, `get`, `keys`, `pairs`
 Based on these methods respective equivalent methods acting
 on an `AbstractSystem` will be automatically available, e.g. using the iteration
 interface of the `AbstractSystem` (see above). Most of the property accessors on the

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -80,7 +80,7 @@ using Unitful, UnitfulAtomic, AtomsBase  # hide
 deuterium = Atom(1, atomic_symbol=:D, [0, 1, 2.]u"bohr")
 ````
 
-An equivalent dict-like interface based on `keys`, `haskey`, `getkey` and `pairs`
+An equivalent dict-like interface based on `keys`, `haskey`, `get` and `pairs`
 is also available. For example
 ````@example atom
 keys(atom)
@@ -229,7 +229,7 @@ Similar to atoms, systems also support storing arbitrary data, for example
 using Unitful, UnitfulAtomic, AtomsBase  # hide
 system = isolated_system([:H => [0, 0, 1.]u"bohr", :H => [0, 0, 3.]u"bohr"]; extra_data=42)
 ````
-Again these custom properties are fully integrated with `keys`, `haskey`, `pairs` and `getkey`.
+Again these custom properties are fully integrated with `keys`, `haskey`, `pairs` and `get`.
 ````@example sysprop
 @show keys(system)
 ````

--- a/src/atom.jl
+++ b/src/atom.jl
@@ -24,8 +24,8 @@ n_dimensions(::Atom{D}) where {D} = D
 
 Base.getindex(at::Atom, x::Symbol) = hasfield(Atom, x) ? getfield(at, x) : getindex(at.data, x)
 Base.haskey(at::Atom,   x::Symbol) = hasfield(Atom, x) || haskey(at.data, x)
-function Base.getkey(at::Atom, x::Symbol, default)
-    hasfield(Atom, x) ? getfield(at, x) : getkey(at.data, x, default)
+function Base.get(at::Atom, x::Symbol, default)
+    hasfield(Atom, x) ? getfield(at, x) : get(at.data, x, default)
 end
 function Base.keys(at::Atom)
     (:position, :velocity, :atomic_symbol, :atomic_number, :atomic_mass, keys(at.data)...)

--- a/src/atomview.jl
+++ b/src/atomview.jl
@@ -19,7 +19,7 @@ Base.show(io::IO, mime::MIME"text/plain", at::AtomView) = show_atom(io, mime, at
 
 Base.getindex(v::AtomView, x::Symbol) = getindex(v.system, v.index, x)
 Base.haskey(v::AtomView, x::Symbol)   = hasatomkey(v.system, x)
-function Base.getkey(v::AtomView, x::Symbol, default)
+function Base.get(v::AtomView, x::Symbol, default)
     hasatomkey(v.system, x) ? v[x] : default
 end
 Base.keys(v::AtomView) = atomkeys(v.system)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -179,6 +179,6 @@ hasatomkey(system::AbstractSystem, x::Symbol) = all(at -> haskey(at, x), system)
 
 # Defaults for system
 Base.pairs(system::AbstractSystem) = (k => system[k] for k in keys(system))
-function Base.getkey(system::AbstractSystem, x::Symbol, default)
+function Base.get(system::AbstractSystem, x::Symbol, default)
     haskey(system, x) ? getindex(system, x) : default
 end

--- a/test/atom.jl
+++ b/test/atom.jl
@@ -65,7 +65,7 @@ using Test
                                    :atomic_number, :atomic_mass)
         @test hasatomkey(system, :atomic_mass)
         @test !hasatomkey(system, :blubber)
-        @test getkey(system, :blubber, :adidi) == :adidi
+        @test get(system, :blubber, :adidi) == :adidi
 
         @test collect(pairs(system)) == [
             :bounding_box => box, :boundary_conditions => bcs,

--- a/test/fast_system.jl
+++ b/test/fast_system.jl
@@ -29,7 +29,7 @@ using PeriodicTable
     @test system[2][:position] == [0.75, 0.75, 0.75]u"m"
     @test haskey(system[1], :position)
     @test !haskey(system[1], :abc)
-    @test getkey(system[1], :dagger, 3) == 3
+    @test get(system[1], :dagger, 3) == 3
 
     @test collect(pairs(system)) == [(:bounding_box => box), (:boundary_conditions => bcs)]
     @test collect(pairs(system[1])) == [

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -21,7 +21,7 @@ using PeriodicTable
         @test atoms[1][:atomic_number] == 6
         @test keys(atoms[1]) == (:position, :velocity, :atomic_symbol,
                                  :atomic_number, :atomic_mass)
-        @test getkey(atoms[1], :blubber, :adidi) == :adidi
+        @test get(atoms[1], :blubber, :adidi) == :adidi
     end
 
     @testset "System" begin


### PR DESCRIPTION
In the current implementation the `getkey` function does something the `get` function ought to be doing (namely to return a property from an atom or system if it exists, otherwise return a default). This is contrast to the way `getkey` behaves in the rest of Julia. This PR fixes this and makes the `get` function behave properly.