### PR TITLE
Slicing support

### DIFF
--- a/src/fast_system.jl
+++ b/src/fast_system.jl
@@ -75,5 +75,7 @@ Base.keys(::FastSystem) = (:bounding_box, :boundary_conditions)
 # Atom and atom property access
 atomkeys(::FastSystem) = (:position, :atomic_symbol, :atomic_number, :atomic_mass)
 hasatomkey(system::FastSystem, x::Symbol) = x in atomkeys(system)
-Base.getindex(system::FastSystem, i::Union{Integer,AbstractVector}, x::Symbol) = getfield(system, x)[i]
+function Base.getindex(system::FastSystem, i::Union{Integer,AbstractVector}, x::Symbol)
+    getfield(system, x)[i]
+end
 Base.getindex(system::FastSystem, ::Colon, x::Symbol) = getfield(system, x)

--- a/src/fast_system.jl
+++ b/src/fast_system.jl
@@ -48,6 +48,8 @@ Base.size(sys::FastSystem)           = size(sys.position)
 
 species_type(::FS) where {FS <: FastSystem} = AtomView{FS}
 Base.getindex(sys::FastSystem, i::Integer)  = AtomView(sys, i)
+Base.getindex(sys::FastSystem, rng::AbstractVector)  = [sys[i] for i in rng]
+Base.getindex(sys::FastSystem, rng::Colon)  = collect(sys)
 
 position(s::FastSystem)       = s.position
 atomic_symbol(s::FastSystem)  = s.atomic_symbol
@@ -75,5 +77,5 @@ Base.keys(::FastSystem) = (:bounding_box, :boundary_conditions)
 # Atom and atom property access
 atomkeys(::FastSystem) = (:position, :atomic_symbol, :atomic_number, :atomic_mass)
 hasatomkey(system::FastSystem, x::Symbol) = x in atomkeys(system)
-Base.getindex(system::FastSystem, i::Integer, x::Symbol) = getfield(system, x)[i]
+Base.getindex(system::FastSystem, i::Union{Integer,AbstractVector}, x::Symbol) = getfield(system, x)[i]
 Base.getindex(system::FastSystem, ::Colon, x::Symbol) = getfield(system, x)

--- a/src/fast_system.jl
+++ b/src/fast_system.jl
@@ -48,9 +48,6 @@ Base.size(sys::FastSystem)           = size(sys.position)
 
 species_type(::FS) where {FS <: FastSystem} = AtomView{FS}
 Base.getindex(sys::FastSystem, i::Integer)  = AtomView(sys, i)
-Base.getindex(sys::FastSystem, rng::AbstractVector)  = [sys[i] for i in rng]
-Base.getindex(sys::FastSystem, rng::AbstractVector{<:Bool})  = sys[(1:length(sys))[rng]]
-Base.getindex(sys::FastSystem, rng::Colon)  = collect(sys)
 
 position(s::FastSystem)       = s.position
 atomic_symbol(s::FastSystem)  = s.atomic_symbol

--- a/src/fast_system.jl
+++ b/src/fast_system.jl
@@ -49,6 +49,7 @@ Base.size(sys::FastSystem)           = size(sys.position)
 species_type(::FS) where {FS <: FastSystem} = AtomView{FS}
 Base.getindex(sys::FastSystem, i::Integer)  = AtomView(sys, i)
 Base.getindex(sys::FastSystem, rng::AbstractVector)  = [sys[i] for i in rng]
+Base.getindex(sys::FastSystem, rng::AbstractVector{<:Bool})  = sys[(1:length(sys))[rng]]
 Base.getindex(sys::FastSystem, rng::Colon)  = collect(sys)
 
 position(s::FastSystem)       = s.position

--- a/src/flexible_system.jl
+++ b/src/flexible_system.jl
@@ -27,7 +27,9 @@ Base.keys(system::FlexibleSystem) = (:bounding_box, :boundary_conditions, keys(s
 # Atom and atom property access
 Base.getindex(system::FlexibleSystem, i::Integer) = system.particles[i]
 Base.getindex(system::FlexibleSystem, i::Integer, x::Symbol) = system.particles[i][x]
-Base.getindex(system::FlexibleSystem, rng::AbstractVector, x::Symbol) = [at[x] for at in system.particles[rng]]
+function Base.getindex(system::FlexibleSystem, i::AbstractVector, x::Symbol)
+    [at[x] for at in system.particles[i]]
+end
 Base.getindex(system::FlexibleSystem, ::Colon, x::Symbol) = [at[x] for at in system.particles]
 
 

--- a/src/flexible_system.jl
+++ b/src/flexible_system.jl
@@ -25,7 +25,7 @@ end
 Base.keys(system::FlexibleSystem) = (:bounding_box, :boundary_conditions, keys(system.data)...)
 
 # Atom and atom property access
-Base.getindex(system::FlexibleSystem, i::Union{Integer, AbstractVector, Colon}) = system.particles[i]
+Base.getindex(system::FlexibleSystem, i::Integer) = system.particles[i]
 Base.getindex(system::FlexibleSystem, i::Integer, x::Symbol) = system.particles[i][x]
 Base.getindex(system::FlexibleSystem, rng::AbstractVector, x::Symbol) = [at[x] for at in system.particles[rng]]
 Base.getindex(system::FlexibleSystem, ::Colon, x::Symbol) = [at[x] for at in system.particles]

--- a/src/flexible_system.jl
+++ b/src/flexible_system.jl
@@ -25,8 +25,9 @@ end
 Base.keys(system::FlexibleSystem) = (:bounding_box, :boundary_conditions, keys(system.data)...)
 
 # Atom and atom property access
-Base.getindex(system::FlexibleSystem, i::Integer) = system.particles[i]
+Base.getindex(system::FlexibleSystem, i::Union{Integer, AbstractVector, Colon}) = system.particles[i]
 Base.getindex(system::FlexibleSystem, i::Integer, x::Symbol) = system.particles[i][x]
+Base.getindex(system::FlexibleSystem, rng::AbstractVector, x::Symbol) = [at[x] for at in system.particles[rng]]
 Base.getindex(system::FlexibleSystem, ::Colon, x::Symbol) = [at[x] for at in system.particles]
 
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -75,9 +75,11 @@ Base.lastindex(s::AbstractSystem) = length(s)
 Base.iterate(sys::AbstractSystem, state = firstindex(sys)) =
     (firstindex(sys) <= state <= length(sys)) ? (@inbounds sys[state], state + 1) : nothing
 Base.eltype(sys::AbstractSystem) = species_type(sys)
-Base.getindex(s::AbstractSystem, rng::AbstractArray) = getindex.(Ref(s), rng)
+Base.getindex(s::AbstractSystem, i::AbstractArray) = getindex.(Ref(s), i)
 Base.getindex(s::AbstractSystem, ::Colon) = collect(s)
-Base.getindex(s::AbstractSystem, r::AbstractVector{<:Bool}) = s[ (firstindex(s):lastindex(s))[r] ]
+function Base.getindex(s::AbstractSystem, r::AbstractVector{Bool})
+    s[ (firstindex(s):lastindex(s))[r] ]
+end
 
 # TODO Support similar, push, ...
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -75,6 +75,9 @@ Base.lastindex(s::AbstractSystem) = length(s)
 Base.iterate(sys::AbstractSystem, state = firstindex(sys)) =
     (firstindex(sys) <= state <= length(sys)) ? (@inbounds sys[state], state + 1) : nothing
 Base.eltype(sys::AbstractSystem) = species_type(sys)
+Base.getindex(s::AbstractSystem, rng::AbstractArray) = getindex.(Ref(s), rng)
+Base.getindex(s::AbstractSystem, ::Colon) = collect(s)
+Base.getindex(s::AbstractSystem, r::AbstractVector{<:Bool}) = s[ (firstindex(s):lastindex(s))[r] ]
 
 # TODO Support similar, push, ...
 

--- a/test/atom.jl
+++ b/test/atom.jl
@@ -59,16 +59,16 @@ using Test
         @test system[:dic]["extradata_dic"] == "44"
         @test system[3] == atoms[3]
         @test system[1:2] == [system[1], system[2]]
-        @test system[[1,3]] == [system[1], system[3]]
+        @test system[[1, 3]] == [system[1], system[3]]
         @test system[[1 3; 2 1]] == [system[1] system[3]; system[2] system[1]]
         @test system[:] == [system[1], system[2], system[3]]
-        @test system[[false,false,true]] == [system[3]]
+        @test system[[false, false, true]] == [system[3]]
         @test system[3, :dat] == 3.0
         @test system[2, :atomic_symbol] == :C
         @test system[1:2, :atomic_number] == [14, 6]
-        @test system[[1,3], :atomic_number] == [14, 1]
+        @test system[[1, 3], :atomic_number] == [14, 1]
         @test system[:, :atomic_number] == [14, 6, 1]
-        @test system[[false,true,true], :atomic_symbol] == [:C,:H]
+        @test system[[false, true, true], :atomic_symbol] == [:C, :H]
         @test atomkeys(system) == (:position, :velocity, :atomic_symbol,
                                    :atomic_number, :atomic_mass)
         @test hasatomkey(system, :atomic_mass)

--- a/test/atom.jl
+++ b/test/atom.jl
@@ -58,8 +58,13 @@ using Test
         @test system[:extradata] == 45
         @test system[:dic]["extradata_dic"] == "44"
         @test system[3] == atoms[3]
+        @test system[1:2] == [system[1], system[2]]
+        @test system[[1,3]] == [system[1], system[3]]
+        @test system[:] == [system[1], system[2], system[3]]
         @test system[3, :dat] == 3.0
         @test system[2, :atomic_symbol] == :C
+        @test system[1:2, :atomic_number] == [14, 6]
+        @test system[[1,3], :atomic_number] == [14, 1]
         @test system[:, :atomic_number] == [14, 6, 1]
         @test atomkeys(system) == (:position, :velocity, :atomic_symbol,
                                    :atomic_number, :atomic_mass)

--- a/test/atom.jl
+++ b/test/atom.jl
@@ -61,11 +61,13 @@ using Test
         @test system[1:2] == [system[1], system[2]]
         @test system[[1,3]] == [system[1], system[3]]
         @test system[:] == [system[1], system[2], system[3]]
+        @test system[[false,false,true]] == [system[3]]
         @test system[3, :dat] == 3.0
         @test system[2, :atomic_symbol] == :C
         @test system[1:2, :atomic_number] == [14, 6]
         @test system[[1,3], :atomic_number] == [14, 1]
         @test system[:, :atomic_number] == [14, 6, 1]
+        @test system[[false,true,true], :atomic_symbol] == [:C,:H]
         @test atomkeys(system) == (:position, :velocity, :atomic_symbol,
                                    :atomic_number, :atomic_mass)
         @test hasatomkey(system, :atomic_mass)

--- a/test/atom.jl
+++ b/test/atom.jl
@@ -60,6 +60,7 @@ using Test
         @test system[3] == atoms[3]
         @test system[1:2] == [system[1], system[2]]
         @test system[[1,3]] == [system[1], system[3]]
+        @test system[[1 3; 2 1]] == [system[1] system[3]; system[2] system[1]]
         @test system[:] == [system[1], system[2], system[3]]
         @test system[[false,false,true]] == [system[3]]
         @test system[3, :dat] == 3.0

--- a/test/fast_system.jl
+++ b/test/fast_system.jl
@@ -25,15 +25,15 @@ using PeriodicTable
     @test hasatomkey(system, :atomic_symbol)
     @test system[1] == AtomView(system, 1)
     @test system[1:2] == [system[1], system[2]]
-    @test system[[2,1]] == [system[2], system[1]]
+    @test system[[2, 1]] == [system[2], system[1]]
     @test system[[1 2; 2 1]] == [system[1] system[2]; system[2] system[1]]
     @test system[:] == [system[1], system[2]]
-    @test system[[false,true]] == [AtomView(system, 2)]
+    @test system[[false, true]] == [AtomView(system, 2)]
     @test system[1, :atomic_number] == 6
     @test system[1:2, :atomic_symbol] == [:C, :C]
-    @test system[[1,2], :atomic_symbol] == [:C, :C]
+    @test system[[1, 2], :atomic_symbol] == [:C, :C]
     @test system[:, :atomic_symbol] == [:C, :C]
-    @test system[[false,true], :atomic_number] == [6]
+    @test system[[false, true], :atomic_number] == [6]
     @test system[2][:position] == system[2, :position]
     @test system[2][:position] == [0.75, 0.75, 0.75]u"m"
     @test haskey(system[1], :position)

--- a/test/fast_system.jl
+++ b/test/fast_system.jl
@@ -27,10 +27,12 @@ using PeriodicTable
     @test system[1:2] == [AtomView(system, 1), AtomView(system, 2)]
     @test system[[1,2]] == [AtomView(system, 1), AtomView(system, 2)]
     @test system[:] == [AtomView(system, 1), AtomView(system, 2)]
+    @test system[[false,true]] == [AtomView(system, 2)]
     @test system[1, :atomic_number] == 6
     @test system[1:2, :atomic_symbol] == [:C, :C]
     @test system[[1,2], :atomic_symbol] == [:C, :C]
     @test system[:, :atomic_symbol] == [:C, :C]
+    @test system[[false,true], :atomic_number] == [6]
     @test system[2][:position] == system[2, :position]
     @test system[2][:position] == [0.75, 0.75, 0.75]u"m"
     @test haskey(system[1], :position)

--- a/test/fast_system.jl
+++ b/test/fast_system.jl
@@ -23,7 +23,13 @@ using PeriodicTable
     @test atomkeys(system) == (:position, :atomic_symbol, :atomic_number, :atomic_mass)
     @test keys(system[1])  == (:position, :atomic_symbol, :atomic_number, :atomic_mass)
     @test hasatomkey(system, :atomic_symbol)
+    @test system[1] == AtomView(system, 1)
+    @test system[1:2] == [AtomView(system, 1), AtomView(system, 2)]
+    @test system[[1,2]] == [AtomView(system, 1), AtomView(system, 2)]
+    @test system[:] == [AtomView(system, 1), AtomView(system, 2)]
     @test system[1, :atomic_number] == 6
+    @test system[1:2, :atomic_symbol] == [:C, :C]
+    @test system[[1,2], :atomic_symbol] == [:C, :C]
     @test system[:, :atomic_symbol] == [:C, :C]
     @test system[2][:position] == system[2, :position]
     @test system[2][:position] == [0.75, 0.75, 0.75]u"m"

--- a/test/fast_system.jl
+++ b/test/fast_system.jl
@@ -24,9 +24,10 @@ using PeriodicTable
     @test keys(system[1])  == (:position, :atomic_symbol, :atomic_number, :atomic_mass)
     @test hasatomkey(system, :atomic_symbol)
     @test system[1] == AtomView(system, 1)
-    @test system[1:2] == [AtomView(system, 1), AtomView(system, 2)]
-    @test system[[1,2]] == [AtomView(system, 1), AtomView(system, 2)]
-    @test system[:] == [AtomView(system, 1), AtomView(system, 2)]
+    @test system[1:2] == [system[1], system[2]]
+    @test system[[2,1]] == [system[2], system[1]]
+    @test system[[1 2; 2 1]] == [system[1] system[2]; system[2] system[1]]
+    @test system[:] == [system[1], system[2]]
     @test system[[false,true]] == [AtomView(system, 2)]
     @test system[1, :atomic_number] == 6
     @test system[1:2, :atomic_symbol] == [:C, :C]


### PR DESCRIPTION
Now with the key-based property interface we can do `system[:, :property]` to get the corresponding `:property` for all atoms. Wouldn't it also make sense to support `system[rng, :property]` for a subset, `rng` of atom indices. Also, from the discussion in #29, I think returning a list of particle objects for slicing is more intuitive and useful. In this PR, I have implemented both of these, i.e., returning vector of particles objects on slicing AbstractSystems and the corresponding extension to the key-based property interface.

For example, with this, we can do `system[atomic_symbol(system) .== :H]` to get all H atoms.

I am just putting this here as a working version to show the usefulness of this feature. Feel free to close this in case we think slicing need not be supported.