### PR TITLE
Add AtomsBaseTesting subpackage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,10 +34,13 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           GROUP: ${{ matrix.group }}
+          GROUP_COVERAGE: true
       - uses: julia-actions/julia-processcoverage@v1
+        with:
+          directories: src,lib/AtomsBaseTesting/src
       - uses: codecov/codecov-action@v3
         with:
-          file: lcov.info
+          files: lcov.info
 
   docs:
     name: Documentation

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,39 +12,30 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.group }} - ${{ github.event_name }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.6'
           - 'nightly'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+        group:
+          - Core
+          - AtomsBaseTesting
     continue-on-error: ${{ matrix.version == 'nightly' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          GROUP: ${{ matrix.group }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
 
@@ -54,7 +45,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.group }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.group }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Manifest.toml
 *.jl.*.cov
 *.jl.cov
 *.jl.mem

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,8 @@ julia = "1.6"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [targets]
-test = ["Test", "Pkg"]
+test = ["Test", "Pkg", "Unitful", "UnitfulAtomic"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Pkg"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ makedocs(;
         "Home" => "index.md",
         "tutorial.md",
         "overview.md",
+        "testing.md",
         "apireference.md"
     ],
     checkdocs=:exports,

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -1,0 +1,17 @@
+# Testing against the AtomsBase interface
+
+The `AtomsBaseTesting` package provides a few utility functions to test
+downstream packages for having properly implemented the `AtomsBase` interface.
+The tests are probably not complete, but they should be a good start ...
+and as always PRs are welcome.
+
+Two functions are provided, namely `make_test_system` to generate standard
+`FlexibleSystem` test systems and `test_approx_eq` for testing approximate
+equality between `AtomsBase` systems (of not necessarily the same type).
+The basic idea of the functions is to use `make_test_system` to obtain a
+test system, construct an identical system in a downstream library and then use
+`test_approx_eq` to check they are actually equal.
+
+For usage examples see the tests of [ExtXYZ](https://github.com/libAtoms/ExtXYZ.jl),
+[AtomsIO](https://github.com/mfherbst/AtomIO.jl)
+and [ASEconnect](https://github.com/mfherbst/ASEconvert.jl).

--- a/lib/AtomsBaseTesting/LICENSE
+++ b/lib/AtomsBaseTesting/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 JuliaMolSim community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/AtomsBaseTesting/Project.toml
+++ b/lib/AtomsBaseTesting/Project.toml
@@ -1,0 +1,17 @@
+name = "AtomsBaseTesting"
+uuid = "ed7c10db-df7e-4efa-a7be-4f4190f7f227"
+authors = ["JuliaMolSim community"]
+version = "0.1.0"
+
+[deps]
+AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
+
+[compat]
+AtomsBase = "0.3"
+Unitful = "1"
+UnitfulAtomic = "1"
+julia = "1.6"

--- a/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
+++ b/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
@@ -53,6 +53,7 @@ function test_approx_eq(s::AbstractSystem, t::AbstractSystem;
         if hasatomkey(s, prop) != hasatomkey(t, prop)
             println("hashatomkey mismatch for $prop")
             @test hasatomkey(s, prop) == hasatomkey(t, prop)
+            continue
         end
         for (at_s, at_t) in zip(s, t)
             @test haskey(at_s, prop) == haskey(at_t, prop)
@@ -77,6 +78,7 @@ function test_approx_eq(s::AbstractSystem, t::AbstractSystem;
         if haskey(s, prop) != haskey(t, prop)
             println("haskey mismatch for $prop")
             @test haskey(s, prop) == haskey(t, prop)
+            continue
         end
 
         if s[prop] isa Quantity
@@ -97,7 +99,6 @@ and specific standard keys can be ignored using `drop_atprop` and `drop_sysprop`
 """
 function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
                           extra_atprop=(; ), extra_sysprop=(; ), cellmatrix=:full)
-    # TODO Should be moved to AtomsBase
     @assert D == 3
     n_atoms = 5
 

--- a/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
+++ b/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
@@ -1,0 +1,161 @@
+module AtomsBaseTesting
+using AtomsBase
+using Test
+using LinearAlgebra
+using Unitful
+using UnitfulAtomic
+
+export test_approx_eq
+export make_test_system
+
+"""
+Test whether two abstract systems are approximately the same. Certain atomic or system
+properties can be ignored during the comparison using the respective kwargs.
+"""
+function test_approx_eq(s::AbstractSystem, t::AbstractSystem;
+                        rtol=1e-14, ignore_atprop=Symbol[], ignore_sysprop=Symbol[],
+                        common_only=false)
+    rnorm(a, b) = (ustrip(norm(a)) < rtol ? norm(a - b) / 1unit(norm(a))
+                                          : norm(a - b) / norm(a))
+
+    for method in (length, size, boundary_conditions)
+        @test method(s) == method(t)
+    end
+
+    @test maximum(map(rnorm, bounding_box(s), bounding_box(t))) < rtol
+    for method in (position, atomic_mass)
+        @test maximum(map(rnorm, method(s), method(t))) < rtol
+        @test rnorm(method(s, 1), method(t, 1)) < rtol
+    end
+
+    for method in (atomic_symbol, atomic_number)
+        @test method(s)    == method(t)
+        @test method(s, 1) == method(t, 1)
+    end
+
+    if !(:velocity in ignore_atprop)
+        @test ismissing(velocity(s)) == ismissing(velocity(t))
+        if !ismissing(velocity(s)) && !ismissing(velocity(t))
+            @test maximum(map(rnorm, velocity(s), velocity(t))) < rtol
+            @test rnorm(velocity(s, 1), velocity(t, 1)) < rtol
+        end
+    end
+
+    if common_only
+        test_atprop = [k for k in atomkeys(s) if hasatomkey(t, k)]
+    else
+        extra_atomic_props = (:charge, :covalent_radius, :vdw_radius, :magnetic_moment)
+        test_atprop = Set([atomkeys(s)..., atomkeys(t)..., extra_atomic_props...])
+    end
+    for prop in test_atprop
+        prop in ignore_atprop && continue
+        prop in (:velocity, :position) && continue
+        if hasatomkey(s, prop) != hasatomkey(t, prop)
+            println("hashatomkey mismatch for $prop")
+            @test hasatomkey(s, prop) == hasatomkey(t, prop)
+        end
+        for (at_s, at_t) in zip(s, t)
+            @test haskey(at_s, prop) == haskey(at_t, prop)
+            if haskey(at_s, prop) && haskey(at_t, prop)
+                if at_s[prop] isa Quantity
+                    @test rnorm(at_s[prop], at_t[prop]) < rtol
+                else
+                    @test at_s[prop] == at_t[prop]
+                end
+            end
+        end
+    end
+
+    if common_only
+        test_sysprop = [k for k in keys(s) if haskey(t, k)]
+    else
+        extra_system_props = (:charge, :multiplicity)
+        test_sysprop = Set([keys(s)..., keys(t)..., extra_system_props...])
+    end
+    for prop in test_sysprop
+        prop in ignore_sysprop && continue
+        if haskey(s, prop) != haskey(t, prop)
+            println("haskey mismatch for $prop")
+            @test haskey(s, prop) == haskey(t, prop)
+        end
+
+        if s[prop] isa Quantity
+            @test rnorm(s[prop], t[prop]) < rtol
+        elseif prop in (:bounding_box, )
+            @test maximum(map(rnorm, s[prop], t[prop])) < rtol
+        else
+            @test s[prop] == t[prop]
+        end
+    end
+end
+
+
+"""
+Setup a standard test system using some random data and supply the data to the caller.
+Extra atomic or system properties can be specified using `extra_atprop` and `extra_sysprop`
+and specific standard keys can be ignored using `drop_atprop` and `drop_sysprop`.
+"""
+function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
+                          extra_atprop=(; ), extra_sysprop=(; ), cellmatrix=:full)
+    # TODO Should be moved to AtomsBase
+    @assert D == 3
+    n_atoms = 5
+
+    # Generate some random data to store in Atoms
+    atprop = Dict{Symbol,Any}(
+        :position        => [randn(3) for _ = 1:n_atoms]u"Å",
+        :velocity        => [randn(3) for _ = 1:n_atoms] * 10^6*u"m/s",
+        #                   Note: reasonable velocity range in au
+        :atomic_symbol   => [:H, :H, :C, :N, :He],
+        :atomic_number   => [1, 1, 6, 7, 2],
+        :charge          => [2, 1, 3.0, -1.0, 0.0]u"e_au",
+        :atomic_mass     => 10rand(n_atoms)u"u",
+        :vdw_radius      => randn(n_atoms)u"Å",
+        :covalent_radius => randn(n_atoms)u"Å",
+        :magnetic_moment => [0.0, 0.0, 1.0, -1.0, 0.0],
+    )
+    sysprop = Dict{Symbol,Any}(
+        :extra_data   => 42,
+        :charge       => -1u"e_au",
+        :multiplicity => 2,
+    )
+
+    for prop in drop_atprop
+        pop!(atprop, prop)
+    end
+    for prop in drop_sysprop
+        pop!(sysprop, prop)
+    end
+    sysprop = merge(sysprop, pairs(extra_sysprop))
+    atprop  = merge(atprop,  pairs(extra_atprop))
+
+    atoms = map(1:n_atoms) do i
+        atargs = Dict(k => v[i] for (k, v) in pairs(atprop)
+                      if !(k in (:position, :velocity)))
+        if haskey(atprop, :velocity)
+            Atom(atprop[:atomic_symbol][i], atprop[:position][i], atprop[:velocity][i];
+                 atargs...)
+        else
+            Atom(atprop[:atomic_symbol][i], atprop[:position][i]; atargs...)
+        end
+    end
+    if cellmatrix == :lower_triangular
+        box = [[1.54732, -0.807289, -0.500870],
+               [    0.0, 0.4654985, 0.5615117],
+               [    0.0,       0.0, 0.7928950]]u"Å"
+    elseif cellmatrix == :upper_triangular
+        box = [[1.54732, 0.0, 0.0],
+               [-0.807289, 0.4654985, 0.0],
+               [-0.500870, 0.5615117, 0.7928950]]u"Å"
+    else
+        box = [[-1.50304, 0.850344, 0.717239],
+               [ 0.36113, 0.008144, 0.814712],
+               [ 0.06828, 0.381122, 0.129081]]u"Å"
+    end
+    bcs = [Periodic(), Periodic(), DirichletZero()]
+    system = atomic_system(atoms, box, bcs; sysprop...)
+
+    (; system, atoms, atprop=NamedTuple(atprop), sysprop=NamedTuple(sysprop), box, bcs)
+end
+
+end

--- a/lib/AtomsBaseTesting/test/runtests.jl
+++ b/lib/AtomsBaseTesting/test/runtests.jl
@@ -2,13 +2,12 @@ using AtomsBaseTesting
 using Test
 using LinearAlgebra
 using AtomsBase
+using Unitful
+using UnitfulAtomic
+
+include("testmacros.jl")
 
 @testset "AtomsBaseTesting.jl" begin
-    @testset "Run generation and testing code" begin
-        case = make_test_system()
-        test_approx_eq(case.system, case.system)
-    end
-
     @testset "make_test_system" begin
         let case = make_test_system(; cellmatrix=:full)
             box = reduce(hcat, bounding_box(case.system))
@@ -32,4 +31,33 @@ using AtomsBase
         @test  haskey(make_test_system().system,                               :multiplicity)
         @test !haskey(make_test_system(; drop_sysprop=[:multiplicity]).system, :multiplicity)
     end
+
+    @testset "Identical systems should pass" begin
+        case = make_test_system()
+        test_approx_eq(case.system, case.system)
+    end
+
+    @testset "Cell distortion" begin
+        (; system, atoms, box, bcs, sysprop) = make_test_system()
+
+        box_dist = [v .+ 1e-5u"Å" * ones(3) for v in box]
+        system_dist = atomic_system(atoms, box_dist, bcs; sysprop...)
+
+        @testfail test_approx_eq(system, system_dist; rtol=1e-12)
+        @testpass test_approx_eq(system, system_dist; rtol=1e-3)
+    end
+
+    @testset "ignore_sysprop / common_only" begin
+        (; system, atoms, box, bcs, sysprop) = make_test_system()
+
+        sysprop_dict = Dict(pairs(sysprop))
+        pop!(sysprop_dict, :multiplicity)
+        system_edit = atomic_system(atoms, box, bcs; sysprop_dict...)
+
+        @testfail test_approx_eq(system, system_edit)
+        @testpass test_approx_eq(system, system_edit; ignore_sysprop=[:multiplicity])
+        @testpass test_approx_eq(system, system_edit; common_only=true)
+    end
+
+    # TODO More tests would be useful
 end

--- a/lib/AtomsBaseTesting/test/runtests.jl
+++ b/lib/AtomsBaseTesting/test/runtests.jl
@@ -49,8 +49,6 @@ include("testmacros.jl")
         sysprop = case.sysprop
         # end simplify
 
-        (; system, atoms, box, bcs, sysprop) = make_test_system()
-
         box_dist = [v .+ 1e-5u"Å" * ones(3) for v in box]
         system_dist = atomic_system(atoms, box_dist, bcs; sysprop...)
 

--- a/lib/AtomsBaseTesting/test/runtests.jl
+++ b/lib/AtomsBaseTesting/test/runtests.jl
@@ -1,0 +1,35 @@
+using AtomsBaseTesting
+using Test
+using LinearAlgebra
+using AtomsBase
+
+@testset "AtomsBaseTesting.jl" begin
+    @testset "Run generation and testing code" begin
+        case = make_test_system()
+        test_approx_eq(case.system, case.system)
+    end
+
+    @testset "make_test_system" begin
+        let case = make_test_system(; cellmatrix=:full)
+            box = reduce(hcat, bounding_box(case.system))
+            @test UpperTriangular(box) != box
+            @test LowerTriangular(box) != box
+        end
+        let case = make_test_system(; cellmatrix=:upper_triangular)
+            box = reduce(hcat, bounding_box(case.system))
+            @test UpperTriangular(box) == box
+            @test LowerTriangular(box) != box
+        end
+        let case = make_test_system(; cellmatrix=:lower_triangular)
+            box = reduce(hcat, bounding_box(case.system))
+            @test UpperTriangular(box) != box
+            @test LowerTriangular(box) == box
+        end
+
+        @test  hasatomkey(make_test_system().system,                            :vdw_radius)
+        @test !hasatomkey(make_test_system(; drop_atprop=[:vdw_radius]).system, :vdw_radius)
+
+        @test  haskey(make_test_system().system,                               :multiplicity)
+        @test !haskey(make_test_system(; drop_sysprop=[:multiplicity]).system, :multiplicity)
+    end
+end

--- a/lib/AtomsBaseTesting/test/runtests.jl
+++ b/lib/AtomsBaseTesting/test/runtests.jl
@@ -38,6 +38,17 @@ include("testmacros.jl")
     end
 
     @testset "Cell distortion" begin
+        # TODO This can be simplified to
+        #      (; system, atoms, box, bcs, sysprop) = make_test_system()
+        # once we require Julia 1.7
+        case = make_test_system()
+        system = case.system
+        atoms = case.atoms
+        box = case.box
+        bcs = case.bcs
+        sysprop = case.sysprop
+        # end simplify
+
         (; system, atoms, box, bcs, sysprop) = make_test_system()
 
         box_dist = [v .+ 1e-5u"Å" * ones(3) for v in box]
@@ -48,7 +59,16 @@ include("testmacros.jl")
     end
 
     @testset "ignore_sysprop / common_only" begin
-        (; system, atoms, box, bcs, sysprop) = make_test_system()
+        # TODO This can be simplified to
+        #      (; system, atoms, box, bcs, sysprop) = make_test_system()
+        # once we require Julia 1.7
+        case = make_test_system()
+        system = case.system
+        atoms = case.atoms
+        box = case.box
+        bcs = case.bcs
+        sysprop = case.sysprop
+        # end simplify
 
         sysprop_dict = Dict(pairs(sysprop))
         pop!(sysprop_dict, :multiplicity)

--- a/lib/AtomsBaseTesting/test/testmacros.jl
+++ b/lib/AtomsBaseTesting/test/testmacros.jl
@@ -1,0 +1,32 @@
+# This file extends
+# https://github.com/JuliaLang/julia/blob/7c8cbf68865c7a8080a43321c99e07224f614e69/stdlib/Test/test/nothrow_testset.jl
+# which is under an MIT licence.
+
+using Test
+
+mutable struct NoThrowTestSet <: Test.AbstractTestSet
+    results::Vector
+    NoThrowTestSet(desc) = new([])
+end
+Test.record(ts::NoThrowTestSet, t::Test.Result) = (push!(ts.results, t); t)
+Test.finish(ts::NoThrowTestSet) = ts.results
+
+
+macro testpass(expr)
+    quote
+        local ts = @testset NoThrowTestSet begin
+            $(esc(expr))
+        end
+        @test  all(t -> t isa Test.Pass,  ts)
+    end
+end
+
+macro testfail(expr)
+    quote
+        local ts = @testset NoThrowTestSet begin
+            $(esc(expr))
+        end
+        @test  any(t -> t isa Test.Fail,  ts)
+        @test !any(t -> t isa Test.Error, ts)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using Pkg
 
 const GROUP = get(ENV, "GROUP", "Core")
+const GROUP_COVERAGE = !isempty(get(ENV, "GROUP_COVERAGE", ""))
 
 if GROUP == "Core"
     @testset "AtomsBase.jl" begin
@@ -14,5 +15,5 @@ if GROUP == "Core"
 else
     subpkg_path = joinpath(dirname(@__DIR__), "lib", GROUP)
     Pkg.develop(PackageSpec(path=subpkg_path))
-    Pkg.test(PackageSpec(name=GROUP, path=subpkg_path))
+    Pkg.test(PackageSpec(name=GROUP, path=subpkg_path), coverage=GROUP_COVERAGE)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,17 @@
-using Test
+using Test, Pkg
 
-@testset "AtomsBase.jl" begin
-    include("interface.jl")
-    include("fast_system.jl")
-    include("atom.jl")
-    include("properties.jl")
-    include("printing.jl")
+const GROUP = get(ENV, "GROUP", "Core")
+
+if GROUP == "Core"
+    @testset "AtomsBase.jl" begin
+        include("interface.jl")
+        include("fast_system.jl")
+        include("atom.jl")
+        include("properties.jl")
+        include("printing.jl")
+    end
+else
+    subpkg_path = joinpath(dirname(@__DIR__), "lib", GROUP)
+    Pkg.develop(PackageSpec(path=subpkg_path))
+    Pkg.test(PackageSpec(name=GROUP, path=subpkg_path))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
-using Test, Pkg
+using Test
+using Pkg
 
 const GROUP = get(ENV, "GROUP", "Core")
 


### PR DESCRIPTION
Adds a small subpackage, which can generate standard test cases and test equality between AtomsBase systems. Already used in ExtXYZ, [AtomsIO](https://github.com/mfherbst/AtomsIO.jl/blob/master/test/common.jl) and [ASEconnect](https://github.com/mfherbst/ASEconvert.jl/blob/master/test/common.jl) for testing (with code duplicated across these three packages). Clearly this has broader use, so this will allow registering a separate `AtomsBaseTesting` package. 