### PR TITLE
Add :diagonal option to test_approx_equal

### DIFF
--- a/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
+++ b/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
@@ -148,10 +148,14 @@ function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
         box = [[1.54732, 0.0, 0.0],
                [-0.807289, 0.4654985, 0.0],
                [-0.500870, 0.5615117, 0.7928950]]u"Å"
+    elseif cellmatrix == :diagonal
+        box = [[1.54732, 0.0, 0.0],
+              [0.0, 0.4654985, 0.0],
+              [0.0, 0.0, 0.7928950]]u"Å"
     else
-        box = [[-1.50304, 0.850344, 0.717239],
-               [ 0.36113, 0.008144, 0.814712],
-               [ 0.06828, 0.381122, 0.129081]]u"Å"
+        box = [[1.50304, 0.850344, 0.717239],
+               [ 0.36113, 1.008144, 0.814712],
+               [ 0.06828, 0.381122, 2.129081]]u"Å"
     end
     bcs = [Periodic(), Periodic(), DirichletZero()]
     system = atomic_system(atoms, box, bcs; sysprop...)

--- a/lib/AtomsBaseTesting/test/runtests.jl
+++ b/lib/AtomsBaseTesting/test/runtests.jl
@@ -29,11 +29,11 @@ include("testmacros.jl")
         end
         let case = make_test_system(; cellmatrix=:diagonal)
             box = reduce(hcat, bounding_box(case.system))
-            @test UpperTriangular(box) != box
-            @test LowerTriangular(box) != box
             @test Diagonal(box) == box
+            @test UpperTriangular(box) == box
+            @test LowerTriangular(box) == box
         end
-
+ 
         @test  hasatomkey(make_test_system().system,                            :vdw_radius)
         @test !hasatomkey(make_test_system(; drop_atprop=[:vdw_radius]).system, :vdw_radius)
 


### PR DESCRIPTION
Added option `:diagonal` to AtomsBaseTesting `test_approx_equal`. The current options are not compatible with Molly.jl (triclinic & DirichletZero) and I would like to test against a valid system.

Also is `DirhichletZero` supposed to be a hard wall or infinite domain or something else?  Doesn't really make a difference for Molly but its not really clear from docs and not something I've ever seen in a molecular simulation context.