### PR TITLE
WIP: Towards Type Stability

### DIFF
--- a/src/AtomsBase.jl
+++ b/src/AtomsBase.jl
@@ -5,9 +5,11 @@ using StaticArrays
 using Requires
 
 include("interface.jl")
+include("chem.jl")
 include("properties.jl")
 include("visualize_ascii.jl")
 include("show.jl")
+include("cell.jl")
 include("flexible_system.jl")
 include("atomview.jl")
 include("atom.jl")

--- a/src/atom.jl
+++ b/src/atom.jl
@@ -128,31 +128,32 @@ atomic_number(atom::FastAtom) = atomic_number(atom.element)
 element(atom::FastAtom)       = atom.element 
 n_dimensions(::FastAtom{D}) where {D} = D
 
-Base.getindex(at::FastAtom, x::Symbol) = hasfield(FastAtom, x) ? getfield(at, x) : missing 
+Base.getindex(at::FastAtom, x::Symbol) =   
+        hasfield(FastAtom, x) ? getfield(at, x) : missing 
 
-Base.haskey(at::FastAtom,   x::Symbol) = hasfield(FastAtom, x)
+Base.haskey(at::FastAtom,   x::Symbol) = 
+        hasfield(FastAtom, x)
 
-function Base.get(at::FastAtom, x::Symbol, default)
-    hasfield(FastAtom, x) ? getfield(at, x) : default 
-end
+Base.get(at::FastAtom, x::Symbol, default) = 
+        hasfield(FastAtom, x) ? getfield(at, x) : default 
 
-function Base.keys(at::FastAtom)
-    (:position, :element, :atomic_mass,)
-end
+Base.keys(at::FastAtom) = 
+        (:position, :element, :atomic_mass,)
 
-Base.pairs(at::FastAtom) = (k => at[k] for k in keys(at))
+Base.pairs(at::FastAtom) = 
+        (k => at[k] for k in keys(at))
 
 
-function Atom(identifier::AtomId, position::AbstractVector{L};
+function FastAtom(identifier::AtomId, position::AbstractVector{L};
               chemical_element = ChemicalElement(identifier),
               atomic_mass::M   = atomic_mass(chemical_element),
-            ) where {L <: Unitful.Length, V <: Unitful.Velocity, M <: Unitful.Mass}
+            ) where {L <: Unitful.Length, M <: Unitful.Mass}
     D = length(position)            
-    return Atom(chemical_element, SVector{D}(position), atomic_mass)
+    return FastAtom(chemical_element, SVector{D}(position), atomic_mass)
 end
 
-function Atom(; atomic_symbol, position, kwargs...)
-    return Atom(atomic_symbol, position; kwargs...)
+function FastAtom(; atomic_symbol, position, kwargs...)
+    return FastAtom(atomic_symbol, position; kwargs...)
 end
 
 

--- a/src/atomview.jl
+++ b/src/atomview.jl
@@ -37,6 +37,7 @@ function velocity(v::AtomView)
     ismissing(vel) && return missing
     return vel[v.index]
 end
+
 position(v::AtomView)      = position(v.system)[v.index]
 atomic_mass(v::AtomView)   = atomic_mass(v.system)[v.index]
 atomic_symbol(v::AtomView) = atomic_symbol(v.system)[v.index]
@@ -48,9 +49,12 @@ Base.show(io::IO, at::AtomView) = show_atom(io, at)
 Base.show(io::IO, mime::MIME"text/plain", at::AtomView) = show_atom(io, mime, at)
 
 Base.getindex(v::AtomView, x::Symbol) = getindex(v.system, v.index, x)
+
 Base.haskey(v::AtomView, x::Symbol)   = hasatomkey(v.system, x)
+
 function Base.get(v::AtomView, x::Symbol, default)
     hasatomkey(v.system, x) ? v[x] : default
 end
+
 Base.keys(v::AtomView) = atomkeys(v.system)
 Base.pairs(at::AtomView) = (k => at[k] for k in keys(at))

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -17,6 +17,21 @@ periodicity(cell::PCell) = cell.pbc
 
 isinfinite(cell::PCell) = map(!, cell.pbc)
 
+n_dimensions(::PCell{D}) where {D} = D
+
+# ---------------------- pretty printing 
+
+function Base.show(io::IO, cell::PCell{D}) where {D} 
+   u = unit(first(cell.cell_vectors[1][1]))
+   println(io, "    PCell(", prod(p -> p ? "T" : "F", cell.pbc), ",")  
+   for d = 1:D 
+      print(io, "          ", ustrip.(cell.cell_vectors[d]), u)
+      d < D && println(",") 
+   end 
+   println(")")
+end
+
+
 # ---------------------- Constructors 
 
 # different ways to construct cell vectors 
@@ -52,9 +67,9 @@ _auto_pbc(bc::Union{Bool, Nothing, BoundaryCondition}, cell_vectors) =
 
 # kwarg constructor for PCell
 
-PCell(; cell_vectors, bc) = 
+PCell(; cell_vectors, boundary_conditions) = 
       PCell(_auto_cell_vectors(cell_vectors), 
-            _auto_pbc(bc, cell_vectors))
+            _auto_pbc(boundary_conditions, cell_vectors))
 
 
 

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -1,0 +1,34 @@
+
+"""
+Implementation of a computational cell for particle systems 
+   within AtomsBase.jl. `PCell` specifies a parallepiped shaped cell 
+   with 
+"""
+struct PCell{D, T}
+   cell_vectors::NTuple{D, SVector{D, T}} 
+   pbc::NTuple{D, Bool}
+end
+
+bounding_box(cell::PCell) = cell.cell_vectors 
+
+boundary_conditions(cell::PCell) = map(p -> p ? Periodic() : OpenBC(), cell.pbc)
+
+periodicity(cell::PCell) = cell.pbc
+
+isinfinite(cell::PCell) = map(!, cell.pbc)
+
+
+# ---------------------- 
+#  interface functions to connect Systems and cells 
+
+bounding_box(system::SystemWithCell{D, <: PCell}) where {D} = 
+   bounding_box(system.cell)
+
+boundary_conditions(system::SystemWithCell{D, <: PCell}) where {D} = 
+   boundary_conditions(system.cell)
+
+periodicity(system::SystemWithCell{D, <: PCell}) where {D} = 
+   periodicity(system.cell)
+
+isinfinite(system::SystemWithCell{D, <: PCell}) where {D} = 
+   isinfinite(system.cell)

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -23,6 +23,16 @@ n_dimensions(::PCell{D}) where {D} = D
 
 function Base.show(io::IO, cell::PCell{D}) where {D} 
    u = unit(first(cell.cell_vectors[1][1]))
+   print(io, "PCell(", prod(p -> p ? "T" : "F", cell.pbc), ", ")  
+   for d = 1:D 
+      print(io, ustrip.(cell.cell_vectors[d]), u)
+      if d < D; print(io, ", "); end 
+   end 
+   println(")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", cell::PCell{D}) where {D} 
+   u = unit(first(cell.cell_vectors[1][1]))
    println(io, "    PCell(", prod(p -> p ? "T" : "F", cell.pbc), ",")  
    for d = 1:D 
       print(io, "          ", ustrip.(cell.cell_vectors[d]), u)
@@ -51,10 +61,11 @@ _auto_cell_vectors(vecs::AbstractVector) =
 
 # different ways to construct PBC 
 
+_auto_pbc1(bc::Bool)   = bc 
 _auto_pbc1(::Periodic) = true 
 _auto_pbc1(::OpenBC)   = false 
 _auto_pbc1(::Nothing)  = false 
-_auto_pbc1(bc::Bool) = bc 
+_auto_pbc1(::DirichletZero)  = false 
 
 _auto_pbc(bc::Tuple, cell_vectors = nothing) = 
       map(_auto_pbc1, bc)

--- a/src/chem.jl
+++ b/src/chem.jl
@@ -14,8 +14,14 @@ struct ChemicalElement
 end
 
 Base.show(io::IO, element::ChemicalElement) = 
-      print(io, atomic_symbol(element))
+      print(io, Symbol(element))
 
+ChemicalElement(sym::Symbol) = ChemicalElement(_sym2z[sym])  
+ChemicalElement(sym::ChemicalElement) = sym
+
+import Base.== 
+
+==(a::ChemicalElement, sym::Symbol) = (Symbol(a) == sym)
 
 # -------- fast access to the periodic table 
 
@@ -28,13 +34,22 @@ const _chem_el_info = [
        for z in 1:length(PeriodicTable.elements)
       ]
 
+const _sym2z = Dict{Symbol, UInt8}() 
+for z in 1:length(_chem_el_info)
+   _sym2z[_chem_el_info[z].symbol] = z
+end
 
 # -------- accessor functions 
 
 atomic_number(element::ChemicalElement) = element.atomic_number
 
-atomic_symbol(element::ChemicalElement) = _chem_el_info[element.atomic_number].symbol
+atomic_symbol(element::ChemicalElement) = element 
+
+Base.convert(::typeof(Symbol), element::ChemicalElement) = Symbol(element) 
+Symbol(element::ChemicalElement) = _chem_el_info[element.atomic_number].symbol
 
 atomic_mass(element::ChemicalElement) = _chem_el_info[element.atomic_number].atomic_mass
 
 rich_info(element::ChemicalElement) = PeriodicTable.elements[element.atomic_number]
+
+element(element::ChemicalElement) = rich_info(element)

--- a/src/chem.jl
+++ b/src/chem.jl
@@ -45,7 +45,7 @@ atomic_number(element::ChemicalElement) = element.atomic_number
 
 atomic_symbol(element::ChemicalElement) = element 
 
-Base.convert(::typeof(Symbol), element::ChemicalElement) = Symbol(element) 
+Base.convert(::Type{Symbol}, element::ChemicalElement) = Symbol(element) 
 Symbol(element::ChemicalElement) = _chem_el_info[element.atomic_number].symbol
 
 atomic_mass(element::ChemicalElement) = _chem_el_info[element.atomic_number].atomic_mass

--- a/src/chem.jl
+++ b/src/chem.jl
@@ -1,0 +1,40 @@
+# --------------------------------------------- 
+#  Simple wrapper for chemical element type 
+
+import PeriodicTable
+using Unitful
+
+
+"""
+Encodes a chemical element by wrapping an integer that represents the atomic 
+number. 
+"""
+struct ChemicalElement
+    atomic_number::UInt8
+end
+
+Base.show(io::IO, element::ChemicalElement) = 
+      print(io, atomic_symbol(element))
+
+
+# -------- fast access to the periodic table 
+
+@assert length(PeriodicTable.elements) == maximum(el.number for el in PeriodicTable.elements)
+@assert all(el.number == i for (i, el) in enumerate(PeriodicTable.elements))
+
+const _chem_el_info = [ 
+      (symbol = Symbol(PeriodicTable.elements[z].symbol), 
+       atomic_mass = PeriodicTable.elements[z].atomic_mass, ) 
+       for z in 1:length(PeriodicTable.elements)
+      ]
+
+
+# -------- accessor functions 
+
+atomic_number(element::ChemicalElement) = element.atomic_number
+
+atomic_symbol(element::ChemicalElement) = _chem_el_info[element.atomic_number].symbol
+
+atomic_mass(element::ChemicalElement) = _chem_el_info[element.atomic_number].atomic_mass
+
+rich_info(element::ChemicalElement) = PeriodicTable.elements[element.atomic_number]

--- a/src/fast_system.jl
+++ b/src/fast_system.jl
@@ -50,8 +50,8 @@ end
 
 get_cell(sys::FastSystem) = sys.cell
 
-Base.length(sys::FastSystem)         = length(sys.position)
-Base.size(sys::FastSystem)           = size(sys.position)
+Base.length(sys::FastSystem)  = length(sys.position)
+Base.size(sys::FastSystem)    = size(sys.position)
 
 species_type(::FS) where {FS <: FastSystem} = AtomView{FS}
 Base.getindex(sys::FastSystem, i::Integer)  = AtomView(sys, i)
@@ -68,10 +68,19 @@ function Base.getindex(system::FastSystem, x::Symbol)
         bounding_box(system)
     elseif x === :boundary_conditions
         boundary_conditions(system)
-    else
+    elseif x === :atomic_number 
+        atomic_number(system)
+    elseif x === :atomic_symbol
+        atomic_symbol(system)
+    elseif x === :position
+        position(system)
+    elseif x === :atomic_mass
+        atomic_mass(system)
+    else 
         throw(KeyError(x))
     end
 end
+
 Base.haskey(::FastSystem, x::Symbol) = x in (:bounding_box, :boundary_conditions)
 Base.keys(::FastSystem) = (:bounding_box, :boundary_conditions)
 
@@ -79,6 +88,6 @@ Base.keys(::FastSystem) = (:bounding_box, :boundary_conditions)
 atomkeys(::FastSystem) = (:position, :atomic_symbol, :atomic_number, :atomic_mass)
 hasatomkey(system::FastSystem, x::Symbol) = x in atomkeys(system)
 function Base.getindex(system::FastSystem, i::Union{Integer,AbstractVector}, x::Symbol)
-    getfield(system, x)[i]
+    getindex(system, x)[i]
 end
-Base.getindex(system::FastSystem, ::Colon, x::Symbol) = getfield(system, x)
+Base.getindex(system::FastSystem, ::Colon, x::Symbol) = getindex(system, x)

--- a/src/fast_system.jl
+++ b/src/fast_system.jl
@@ -3,12 +3,10 @@
 #
 export FastSystem
 
-struct FastSystem{D, L <: Unitful.Length, M <: Unitful.Mass} <: AbstractSystem{D}
-    bounding_box::SVector{D, SVector{D, L}}
-    boundary_conditions::SVector{D, BoundaryCondition}
+struct FastSystem{D, TCELL, L <: Unitful.Length, M <: Unitful.Mass} <: SystemWithCell{D, TCELL}
+    cell::TCELL 
+    chemical_element::Vector{ChemicalElement}
     position::Vector{SVector{D, L}}
-    atomic_symbol::Vector{Symbol}
-    atomic_number::Vector{Int}
     atomic_mass::Vector{M}
 end
 

--- a/src/flexible_system.jl
+++ b/src/flexible_system.jl
@@ -12,6 +12,8 @@ end
 
 # System property access
 
+get_cell(sys::FlexibleSystem) = sys.cell
+
 function Base.getindex(system::FlexibleSystem, x::Symbol)
     if x === :bounding_box
         bounding_box(system)
@@ -66,8 +68,11 @@ function FlexibleSystem(
     if !all(length.(box) .== D)
         throw(ArgumentError("Box must have D vectors of length D"))
     end
-    cell = PCell(box, boundary_conditions)
-    FlexibleSystem(particles, box, boundary_conditions, Dict(kwargs...))
+    cell = PCell(; cell_vectors = box, 
+                   boundary_conditions = boundary_conditions)
+    TPART = eltype(particles)
+    TCELL = typeof(cell)                   
+    FlexibleSystem{D, TPART, TCELL}(particles, cell, Dict{Symbol, Any}(kwargs...))
 end
 
 function FlexibleSystem(particles; bounding_box, boundary_conditions, kwargs...)

--- a/src/flexible_system.jl
+++ b/src/flexible_system.jl
@@ -4,11 +4,10 @@
 export FlexibleSystem
 
 
-struct FlexibleSystem{D, S, L<:Unitful.Length} <: AbstractSystem{D}
-    particles::AbstractVector{S}
-    bounding_box::SVector{D, SVector{D, L}}
-    boundary_conditions::SVector{D, BoundaryCondition}
-    data::Dict{Symbol, Any}  # Store arbitrary data about the atom.
+mutable struct FlexibleSystem{D, TPART, TCELL} <: SystemWithCell{D, TCELL}
+    particles::AbstractVector{TPART}
+    cell::TCELL 
+    data::Dict{Symbol, Any}  # Store arbitrary data about the system
 end
 
 # System property access
@@ -86,9 +85,8 @@ julia> AbstractSystem(system; bounding_box= ..., atoms = ... )
 """
 AbstractSystem(system::AbstractSystem; kwargs...) = FlexibleSystem(system; kwargs...)
 
-bounding_box(sys::FlexibleSystem)        = sys.bounding_box
-boundary_conditions(sys::FlexibleSystem) = sys.boundary_conditions
 species_type(sys::FlexibleSystem{D, S, L}) where {D, S, L} = S
 
 Base.size(sys::FlexibleSystem)   = size(sys.particles)
+
 Base.length(sys::FlexibleSystem) = length(sys.particles)

--- a/src/flexible_system.jl
+++ b/src/flexible_system.jl
@@ -37,17 +37,30 @@ Base.size(sys::FlexibleSystem)   = size(sys.particles)
 Base.length(sys::FlexibleSystem) = length(sys.particles)
 
 Base.getindex(system::FlexibleSystem, i::Union{Integer, AbstractVector}) = 
-        system.particles[i]
+        getindex(system.particles, i)
+Base.getindex(system::FlexibleSystem, i::AbstractVector{Bool}) = 
+        getindex(system.particles, i)
 
 Base.getindex(system::FlexibleSystem, i::Integer, x::Symbol) = 
         system.particles[i][x]
 
 Base.getindex(system::FlexibleSystem, i::AbstractVector, x::Symbol) = 
-        Base.getindex.(Ref(system), i, x)
+        Base.getindex.(system[i], x)
 
 Base.getindex(system::FlexibleSystem, ::Colon, x::Symbol) = 
-        [at[x] for at in system.particles]
+        Base.getindex.(system.particles, x)
 
+
+for f in (:position, :velocity, :atomic_mass, :atomic_symbol, :atomic_number)
+    @eval (Base.getindex(sys::FlexibleSystem, i::Integer, ::typeof($f)) = 
+                $f(sys.particles[i])) 
+    @eval (Base.getindex(sys::FlexibleSystem, inds::AbstractVector, ::typeof($f)) = 
+                [ $f(sys.particles[i]) for i in inds ] )
+    @eval (Base.getindex(sys::FlexibleSystem, ::Colon, ::typeof($f)) = 
+                [ $f(x) for x in sys.particles ] )
+    @eval (Base.getindex(sys::FlexibleSystem, inds::AbstractVector{Bool}, ::typeof($f)) = 
+                [ $f(x) for x in sys.particles[inds] ] )
+end
 
 # ------------ Constructors         
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -31,6 +31,12 @@ A `D`-dimensional system.
 """
 abstract type AbstractSystem{D} end
 
+"""
+    SystemWithCell{D, TCELL}
+
+A `D`-dimensional system with a computational cell of type `TCELL`.
+"""
+
 abstract type SystemWithCell{D, TCELL} <: AbstractSystem{D} end 
 
 """
@@ -55,10 +61,17 @@ Return the type used to represent a species or atom.
 function species_type end
 
 """Return vector indicating whether the system is periodic along a dimension."""
-periodicity(sys::AbstractSystem) = [isa(bc, Periodic) for bc in boundary_conditions(sys)]
+function periodicity(sys::AbstractSystem{D}) where {D} 
+    bc = boundary_conditions(sys) 
+    return ntuple(i -> isa(bc[i], Periodic), D) 
+end
 
 """Returns true if the given system is infinite"""
-isinfinite(sys::AbstractSystem{D}) where {D} = bounding_box(sys) == infinite_box(D)
+function isinfinite end 
+
+# CO: I think this is a dangerous default implementation and I would like to 
+#     remove it entirely. 
+# isinfinite(sys::AbstractSystem{D}) where {D} = bounding_box(sys) == infinite_box(D)
 
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -13,6 +13,7 @@ export atomkeys, hasatomkey
 abstract type BoundaryCondition end
 struct DirichletZero <: BoundaryCondition end  # Dirichlet zero boundary (i.e. molecular context)
 struct Periodic <: BoundaryCondition end  # Periodic BCs
+struct OpenBC <: BoundaryCondition end 
 
 infinite_box(::Val{1}) = [[Inf]]u"bohr"
 infinite_box(::Val{2}) = [[Inf, 0], [0, Inf]]u"bohr"
@@ -29,6 +30,8 @@ infinite_box(dim::Int) = infinite_box(Val(dim))
 A `D`-dimensional system.
 """
 abstract type AbstractSystem{D} end
+
+abstract type SystemWithCell{D, TCELL} <: AbstractSystem{D} end 
 
 """
     bounding_box(sys::AbstractSystem{D})

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -245,6 +245,7 @@ hasatomkey(system::AbstractSystem, x::Symbol) = all(at -> haskey(at, x), system)
 
 # Defaults for system
 Base.pairs(system::AbstractSystem) = (k => system[k] for k in keys(system))
+
 function Base.get(system::AbstractSystem, x::Symbol, default)
     haskey(system, x) ? getindex(system, x) : default
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,8 +2,10 @@ import Base.position
 import PeriodicTable
 
 export AbstractSystem
-export BoundaryCondition, DirichletZero, Periodic, infinite_box, isinfinite
-export bounding_box, boundary_conditions, periodicity, n_dimensions, species_type
+export BoundaryCondition, DirichletZero, Periodic, OpenBC, 
+       infinite_box, isinfinite
+export bounding_box, boundary_conditions, periodicity, n_dimensions, species_type, 
+        get_cell 
 export position, velocity, element, element_symbol, atomic_mass, atomic_number, atomic_symbol
 export atomkeys, hasatomkey
 
@@ -36,8 +38,15 @@ abstract type AbstractSystem{D} end
 
 A `D`-dimensional system with a computational cell of type `TCELL`.
 """
-
 abstract type SystemWithCell{D, TCELL} <: AbstractSystem{D} end 
+
+
+"""
+    get_cell(sys::SystemWithCell)
+
+Returns the cell object defining the computational cell 
+"""
+function get_cell end 
 
 """
     bounding_box(sys::AbstractSystem{D})
@@ -70,7 +79,8 @@ end
 function isinfinite end 
 
 # CO: I think this is a dangerous default implementation and I would like to 
-#     remove it entirely. 
+#     remove it entirely. The reason I don't like it is that the typical case is 
+#     that a system is infinite in specific directions. 
 # isinfinite(sys::AbstractSystem{D}) where {D} = bounding_box(sys) == infinite_box(D)
 
 
@@ -133,13 +143,13 @@ Return the symbols corresponding to the elements of the atoms. Note that
 this may be different than `atomic_symbol` for cases where `atomic_symbol`
 is chosen to be more specific (i.e. designate a special atom).
 """
-function element_symbol(system::AbstractSystem)
-    # Note that atomic_symbol cannot be used here, since this may map
-    # to something more specific than the element
-    [Symbol(element(num).symbol) for num in atomic_number(system)]
-end
-element_symbol(sys::AbstractSystem, index) = element_symbol(sys[index])
-element_symbol(species) = Symbol(element(atomic_number(species)).symbol)
+element_symbol(system::AbstractSystem) = element_symbol.(atomic_number(system))
+element_symbol(z::Integer) = Symbol(PeriodicTable.elements[z].symbol)
+element_symbol(sys::AbstractSystem, index) = element_symbol(atomic_number(sys[index]))
+# element_symbol(species) = Symbol(element(atomic_number(species)).symbol)
+
+# Note that atomic_symbol cannot be used here, since this may map
+# to something more specific than the element
 
 
 """

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -1,5 +1,8 @@
 export chemical_formula
 
+chemical_formula(symbols::AbstractVector{ChemicalElement}) = 
+        chemical_formula(atomic_symbol.(symbols))
+
 """
 Returns the chemical formula of an AbstractSystem as a string.
 """

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -19,4 +19,5 @@ function chemical_formula(symbols::AbstractVector{Symbol})
     end
     join(sort(parts))
 end
-chemical_formula(system::AbstractSystem) = chemical_formula(element_symbol(system))
+chemical_formula(system::AbstractSystem) = 
+        chemical_formula(element_symbol(system))

--- a/src/show.jl
+++ b/src/show.jl
@@ -22,53 +22,25 @@ function show_system(io::IO, system::AbstractSystem{D}) where {D}
     end
     print(io, ")")
 end
+
 function show_system(io::IO, ::MIME"text/plain", system::AbstractSystem{D}) where {D}
-    bc  = boundary_conditions(system)
-    box = bounding_box(system)
-    print(io, typeof(system).name.name, "($(chemical_formula(system))")
-    if isinfinite(system)
-        print(io, ", infinite")
-    else
-        perstr = [p ? "T" : "F" for p in periodicity(system)]
-        print(io, ", periodic = ", join(perstr, ""))
-    end
-    println(io, "):")
+    println(io, typeof(system).name.name, "($(chemical_formula(system))")
+    print(io, get_cell(system))
 
-    extra_line = false
-    if !isinfinite(system)
-        extra_line = true
-        box = bounding_box(system)
-        bunit = unit(eltype(first(bounding_box(system))))
-        for (i, bvector) in enumerate(box)
-            if i == 1
-                @printf io "    %-17s : [" "bounding_box"
-            else
-                print(io, " "^25)
-            end
-            boxstr = [(@sprintf "%8.6g" ustrip(b)) for b in bvector]
-            print(io, join(boxstr, " "))
-            println(io, i == D ? "]u\"$bunit\"" : ";")
-        end
-    end
-
-    for (k, v) in pairs(system)
-        k in (:bounding_box, :boundary_conditions) && continue
-        extra_line = true
-        @printf io "    %-17s : %s\n" string(k) string(v)
-    end
     if length(system) < 10
-        extra_line && println(io)
         for atom in system
             println(io, "    ", atom)
         end
         extra_line = true
     end
 
-    ascii = visualize_ascii(system)
-    if !isempty(ascii)
-        extra_line && println(io)
-        println(io, "   ", replace(ascii, "\n" => "\n   "))
-    end
+    # TODO: this currently fails, but I don't know how to 
+    #       fix it. Need to return to it. 
+    # ascii = visualize_ascii(system)
+    # if !isempty(ascii)
+    #     extra_line && println(io)
+    #     println(io, "   ", replace(ascii, "\n" => "\n   "))
+    # end
 end
 
 Base.show(io::IO, system::AbstractSystem) = show_system(io, system)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -31,6 +31,11 @@ using PeriodicTable
         #                          :atomic_number, :atomic_mass)
         @test get(atoms[1], :blubber, :adidi) == :adidi
         @test get(fatoms[1], :blubber, :adidi) == :adidi
+
+        for f in (velocity, position, atomic_mass, atomic_symbol, atomic_number, element)
+            @test atoms[1][f] === f(atoms[1])
+            @test fatoms[1][f] === f(fatoms[1])
+        end
     end
 
     @testset "System" begin

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -24,11 +24,9 @@ using PeriodicTable
         @test atomic_mass(fatoms[1])   == 12.011u"u"
         @test element(atoms[1]) == element(:C)
         @test element(fatoms[1]) == element(:C)
-        # CO: I've removed the following tests - they are not part of the public 
-        #     interface but of the implementatio details. We can discuss
-        # @test atoms[1][:atomic_number] == 6
-        # @test keys(atoms[1]) == (:position, :velocity, :atomic_symbol,
-        #                          :atomic_number, :atomic_mass)
+        @test atoms[1][atomic_number] == 6
+        @test keys(atoms[1]) == (:position, :velocity, :chemical_element, 
+                                 :atomic_mass)
         @test get(atoms[1], :blubber, :adidi) == :adidi
         @test get(fatoms[1], :blubber, :adidi) == :adidi
 
@@ -65,13 +63,11 @@ using PeriodicTable
         @test atomic_number(flexible, 2) == 6
         @test atomic_mass(flexible, 1)   == PeriodicTable.elements[6].atomic_mass
 
-        # CO: again this is not public interface so I think should not be tested 
-        #     but we can discuss this 
-        # @test atomkeys(flexible) == (:position, :velocity, :atomic_symbol,
-        #                              :atomic_number, :atomic_mass)
-        # @test hasatomkey(flexible, :atomic_number)
-        # @test flexible[1, :atomic_symbol] == :C
-        # @test flexible[:, :atomic_symbol] == [:C, :C]
+        @test atomkeys(flexible) == (:position, :velocity, :chemical_element,
+                                     :atomic_mass)
+        @test hasatomkey(flexible, :chemical_element)
+        @test flexible[1, atomic_symbol] == :C
+        @test all(flexible[:, atomic_symbol] .== [:C, :C])
         @test atomic_symbol(flexible[1]) == :C
         @test atomic_symbol.(flexible[:]) == [:C, :C] 
 

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -13,12 +13,12 @@ using Test
 
     flexible_system = periodic_system(atoms, box; fractional=true, data=-12)
     @test repr(flexible_system) == """
-    FlexibleSystem(CSi, periodic = TTT, bounding_box = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
+    FlexibleSystem(CSi, PCell(TTT, [10.0, 0.0, 0.0]a₀, [0.0, 5.0, 0.0]a₀, [0.0, 0.0, 7.0]a₀)"""
     show(stdout, MIME("text/plain"), flexible_system)
 
     fast_system = FastSystem(flexible_system)
     @test repr(fast_system) == """
-    FastSystem(CSi, periodic = TTT, bounding_box = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
+    FastSystem(CSi, PCell(TTT, [10.0, 0.0, 0.0]a₀, [0.0, 5.0, 0.0]a₀, [0.0, 0.0, 7.0]a₀)"""
     show(stdout, MIME("text/plain"), fast_system)
     show(stdout, MIME("text/plain"), fast_system[1])
 end


### PR DESCRIPTION
This PR is to address a number of itches I have with the current implementation of the interface and its implementation. ~~So far the goal is to keep it entirely backward compatible. I think this may be possible.~~  I believe I am still very close to backward compatible in the interface, though no longer in the internals. 

The plan is to address the following issues: 
- [x] #99 
- [x] #97 
- [x] #49 
- [x] #5 
- [x] some discussions elsewhere about having a type-stable and isbits atoms type.
- [x] an ad-hoc decision to make `FlexibleSystem` mutable since it is supposed to be flexible? This will be good for `AtomsBuilder`
- [x] #102 

This is now ready for comments.

### Bugs and TODOs 

- [ ] make all tests pass
- [ ] write tests to show equivalent when using `FastAtom` 
- [ ] write tests that show performance when using `FastAtom` 
- [ ] cannot reinterpret `ChemicalElement` as `UInt8`
- [ ] I would like to delete or deprecate `DirichletZero`
- [ ] I would like to replace `AtomView` with `FastAtom` for `fast_system[i]`. The latter is "isbits" and hence performant. Also much much easier to use and implement, basically working like an `SVector`. 
