### PR TITLE
Fix #117

### DIFF
--- a/src/implementation/flexible_system.jl
+++ b/src/implementation/flexible_system.jl
@@ -54,14 +54,6 @@ function FlexibleSystem(
         pbc::AUTOPBC{D};
         kwargs...
     ) where {S, D}
-    # if periodicity isa Bool 
-    #     periodicity = ntuple(_ -> periodicity, D)
-    # else 
-    #     periodicity = tuple(periodicity...)
-    # end
-    # if !all(length.(box) .== D)
-    #     throw(ArgumentError("Box must have D vectors of length D"))
-    # end
     cϵll = PeriodicCell(; cell_vectors = box, periodicity = pbc)
     FlexibleSystem{D, S, typeof(cϵll)}(particles, cϵll, Dict(kwargs...))
 end

--- a/src/implementation/flexible_system.jl
+++ b/src/implementation/flexible_system.jl
@@ -49,20 +49,20 @@ Construct a flexible system, a versatile data structure for atomistic systems,
 which puts an emphasis on flexibility rather than speed.
 """
 function FlexibleSystem(
-    particles::AbstractVector{S},
-    box::NTuple{D, <: AbstractVector{L}},
-    periodicity::Union{Bool, NTuple{D, Bool}, AbstractVector{<: Bool}};
-    kwargs...
-) where {L<:Unitful.Length, S, D}
-    if periodicity isa Bool 
-        periodicity = ntuple(_ -> periodicity, D)
-    else 
-        periodicity = tuple(periodicity...)
-    end
-    if !all(length.(box) .== D)
-        throw(ArgumentError("Box must have D vectors of length D"))
-    end
-    cϵll = PeriodicCell(; cell_vectors = box, periodicity = periodicity)
+        particles::AbstractVector{S},
+        box::AUTOBOX{D},
+        pbc::AUTOPBC{D};
+        kwargs...
+    ) where {S, D}
+    # if periodicity isa Bool 
+    #     periodicity = ntuple(_ -> periodicity, D)
+    # else 
+    #     periodicity = tuple(periodicity...)
+    # end
+    # if !all(length.(box) .== D)
+    #     throw(ArgumentError("Box must have D vectors of length D"))
+    # end
+    cϵll = PeriodicCell(; cell_vectors = box, periodicity = pbc)
     FlexibleSystem{D, S, typeof(cϵll)}(particles, cϵll, Dict(kwargs...))
 end
 

--- a/src/utils/cells.jl
+++ b/src/utils/cells.jl
@@ -75,6 +75,16 @@ end
 # ---------------------------------------------
 #     Utilities 
 
+# allowed input types that convert automatically to the 
+# intended format for cell vectors,  NTuple{D, SVector{D, T}}
+const AUTOBOX = Union{NTuple{D, <: AbstractVector}, 
+                  AbstractVector{<: AbstractVector}} where {D}
+
+# allowed input types that convert automatically to the 
+# intended format for pbc,  NTuple{D, Bool}
+const AUTOPBC = Union{Bool, 
+                      NTuple{D, Bool}, 
+                      AbstractVector{<: Bool}} where {D} 
 
 # different ways to construct cell vectors 
 
@@ -86,7 +96,7 @@ function _auto_cell_vectors(vecs::Tuple)
    return ntuple(i -> SVector{D}(vecs[i]), D)
 end
 
-_auto_cell_vectors(vecs::AbstractVector) = 
+_auto_cell_vectors(vecs::AbstractVector{<: AbstractVector}) = 
       _auto_cell_vectors(tuple(vecs...))
 
 # .... could consider allowing construction from a matrix but 

--- a/src/utils/cells.jl
+++ b/src/utils/cells.jl
@@ -39,12 +39,12 @@ Implementation of a computational cell for particle systems
 """
 struct PeriodicCell{D, T}
    cell_vectors::NTuple{D, SVector{D, T}} 
-   pbc::NTuple{D, Bool}
+   periodicity::NTuple{D, Bool}
 end
 
 bounding_box(cell::PeriodicCell) = cell.cell_vectors 
 
-periodicity(cell::PeriodicCell) = cell.pbc
+periodicity(cell::PeriodicCell) = cell.periodicity
 
 n_dimensions(::PeriodicCell{D}) where {D} = D
 
@@ -62,7 +62,7 @@ PeriodicCell(cl::Union{AbstractSystem, PeriodicCell}) =
 
 function Base.show(io::IO, cϵll::PeriodicCell{D}) where {D} 
    u = unit(first(cϵll.cell_vectors[1][1]))
-   print(io, "PeriodicCell(", prod(p -> p ? "T" : "F", cϵll.pbc), ", ")  
+   print(io, "PeriodicCell(", prod(p -> p ? "T" : "F", periodicity(cϵll)), ", ")
    for d = 1:D 
       print(io, ustrip.(cϵll.cell_vectors[d]), u)
       if d < D; print(io, ", "); end 
@@ -78,7 +78,7 @@ end
 # allowed input types that convert automatically to the 
 # intended format for cell vectors,  NTuple{D, SVector{D, T}}
 const AUTOBOX = Union{NTuple{D, <: AbstractVector}, 
-                  AbstractVector{<: AbstractVector}} where {D}
+                      AbstractVector{<: AbstractVector}} where {D}
 
 # allowed input types that convert automatically to the 
 # intended format for pbc,  NTuple{D, Bool}
@@ -105,7 +105,7 @@ _auto_cell_vectors(vecs::AbstractVector{<: AbstractVector}) =
 
 # different ways to construct PBC 
 
-_auto_pbc1(bc::Bool)   = bc 
+_auto_pbc1(pbc::Bool)  = pbc 
 _auto_pbc1(::Nothing)  = false 
 
 _auto_pbc(bc::Tuple, cell_vectors = nothing) = 

--- a/test/test_docstrings.jl
+++ b/test/test_docstrings.jl
@@ -1,0 +1,65 @@
+
+# this set of tests is intended to confirm that docstrings throughout the 
+# codebase actually run. Currently, this is just a rough draft that includes 
+# specific doc strings that have been reported to fail. There should be a more 
+# natural and automated way to test this. 
+
+using Unitful
+using UnitfulAtomic
+using AtomsBase
+using Test 
+
+## 
+# atomic_system docstring
+
+try 
+   bounding_box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+   pbcs = (true, true, false)
+   hydrogen = atomic_system([:H => [0, 0, 1.]u"bohr",
+                                 :H => [0, 0, 3.]u"bohr"],
+                                  bounding_box, pbcs)
+   @test true
+catch 
+   @error("atomic_system docstring failed to run")
+   @test false 
+end
+
+
+##
+# isolated_system docstring
+
+try 
+   isolated_system([:H => [0, 0, 1.]u"bohr", :H => [0, 0, 3.]u"bohr"])
+   @test true
+catch
+   @error("isolated_system docstring failed to run")
+   @test false 
+end
+
+##
+# periodic_system docstring 1 
+
+try 
+   bounding_box = ([10.0, 0.0, 0.0]u"Å", [0.0, 10.0, 0.0]u"Å", [0.0, 0.0, 10.0]u"Å")
+   hydrogen = periodic_system([:H => [0, 0, 1.]u"bohr",
+                                      :H => [0, 0, 3.]u"bohr"],
+                                     bounding_box)
+   @test true 
+catch e 
+   @error("periodic_system docstring 1 failed to run")
+   @test false 
+end 
+
+##
+# periodic
+
+try 
+   box = 10.26 / 2 * [[0, 0, 1], [1, 0, 1], [1, 1, 0]]u"bohr"
+   silicon = periodic_system([:Si =>  ones(3)/8,
+                                     :Si => -ones(3)/8],
+                                    box, fractional=true)
+   @test true 
+catch e
+   @error("periodic_system docstring 2 failed to run")
+   @test false 
+end


### PR DESCRIPTION
- fix #117 
- started implementing tests of docstrings 
- improve type signatures to allow auto-conversion of cell vectors and PBC

The last point is the main change: introduced `AUTOBOX` and `AUTOCELL` union types, added those to various function type signatures. These unions describe which input types for cell vectors / bounding box and pbcs can be converted into the required format via `_auto_cell_vectors` and `_auto_pbc` (cf. `cell.jl`). E.g. internally the cell vectors are always stured as `NTuple{D, SVector{D, T}}` but it can be more convenient to construct them as 
```julia
[[ a, 0, 0 ], [0, b, 0], [0, c, d] ] * u"nm"
```
and `_auto_cell_vectors` will then convert.