### PR TITLE
Introduce preference for automatic ascii visualization of system

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,14 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
           - '1.9'
           - '1.10'
-          - 'nightly'
+          - 'latest'
         group:
           - Core
           - AtomsBaseTesting
-    continue-on-error: ${{ matrix.version == 'nightly' }}
+    continue-on-error: ${{ matrix.version == 'latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,11 +20,11 @@ jobs:
         version:
           - '1.9'
           - '1.10'
-          - 'latest'
+          - 'nightly'
         group:
           - Core
           - AtomsBaseTesting
-    continue-on-error: ${{ matrix.version == 'latest' }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.5.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -14,6 +15,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
 PeriodicTable = "1"
+Preferences = "1.4"
 Requires = "1"
 StaticArrays = "1"
 Unitful = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -13,14 +13,21 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
+[weakdeps]
+AtomsView = "ee286e10-dd2d-4ff2-afcb-0a3cd50c8041"
+
+[extensions]
+AtomsBaseAtomsViewExt = "AtomsView"
+
 [compat]
+AtomsView = "0.1"
 PeriodicTable = "1"
 Preferences = "1.4"
 Requires = "1"
 StaticArrays = "1"
 Unitful = "1"
 UnitfulAtomic = "1"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/ext/AtomsBaseAtomsViewExt.jl
+++ b/ext/AtomsBaseAtomsViewExt.jl
@@ -1,0 +1,8 @@
+module AtomsBaseAtomsViewExt
+    using AtomsBase
+    using AtomsView
+
+    function Base.show(io::IO, mime::MIME"text/html", system::AbstractSystem)
+        write(io, AtomsView.visualize_structure(system, mime))
+    end
+end

--- a/src/AtomsBase.jl
+++ b/src/AtomsBase.jl
@@ -18,24 +18,10 @@ include("utils/visualize_ascii.jl")
 include("utils/show.jl")
 include("utils/atomview.jl")
 
-
 # prototype implementations
 include("implementation/atom.jl")
 include("implementation/flexible_system.jl")
 include("implementation/fast_system.jl")
 include("implementation/utils.jl")
-
-
-# TODO:
-#  - this should be converted to an extension
-#  - should work for AbstractSystem
-function __init__()
-    @require AtomsView="ee286e10-dd2d-4ff2-afcb-0a3cd50c8041" begin
-        function Base.show(io::IO, mime::MIME"text/html", system::FlexibleSystem)
-            write(io, AtomsView.visualize_structure(system, mime))
-        end
-    end
-end
-
 
 end

--- a/src/implementation/atom.jl
+++ b/src/implementation/atom.jl
@@ -50,8 +50,8 @@ Supported `kwargs` include `species`, `mass`, as well as user-specific custom pr
 """
 function Atom(identifier::AtomId,
               position::AbstractVector{L},
-              velocity::AbstractVector{V} = _default_velocity(position); 
-              species = ChemicalSpecies(identifier),
+              velocity::AbstractVector{V}=_default_velocity(position);
+              species=ChemicalSpecies(identifier),
               mass::M=mass(species),
               kwargs...) where {L <: Unitful.Length, V <: Unitful.Velocity, M <: Unitful.Mass}
     Atom{length(position), L, V, M}(position, velocity, species,

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -6,17 +6,18 @@ Configures the printing behaviour of `show_system`, which is invoked when a rich
 display of an `AbstractSystem` is requested. This is for example the case in a Julia REPL.
 The following options can be configured:
 
-- `max_species_list`: Maximal number of species in a system (`length(system)`) to trigger a
-   listing of every species along with its Cartesian positions. Default 10
-- `max_species_visualize_ascii`: Maximal number of species in a system to trigger a representation
-   in the form of an ascii cartoon using `visualize_ascii`. Default 0, i.e. diseabled.
+- `max_particles_list`: Maximal number of particles in a system until `show_system`
+  includes a listing of every particle. Default: 10
+- `max_particles_visualize_ascii`: Maximal number of particles in a system
+  until `show_system` includes a representation of the system in the form of
+  an ascii cartoon using `visualize_ascii`. Default 0, i.e. disabled.
 """
-function set_show_preferences!(; max_species_list=nothing, max_species_visualize_ascii=nothing)
-    if !isnothing(max_species_list)
-        @set_preferences!("max_species_list" => max_species_list)
+function set_show_preferences!(; max_particles_list=nothing, max_particles_visualize_ascii=nothing)
+    if !isnothing(max_particles_list)
+        @set_preferences!("max_particles_list" => max_particles_list)
     end
-    if !isnothing(max_species_visualize_ascii)
-        @set_preferences!("max_species_visualize_ascii" => max_species_visualize_ascii)
+    if !isnothing(max_particles_visualize_ascii)
+        @set_preferences!("max_particles_visualize_ascii" => max_particles_visualize_ascii)
     end
     show_preferences()
 end
@@ -26,11 +27,9 @@ Display the current printing behaviour of `show_system`.
 See [`set_show_preferences!](@ref) for more details on the keys.
 """
 function show_preferences()
-    (; max_species_list=@load_preference("max_species_list", 10),
-       max_species_visualize_ascii=@load_preference("max_species_visualize_ascii", 0))
+    (; max_particles_list=@load_preference("max_particles_list", 10),
+       max_particles_visualize_ascii=@load_preference("max_particles_visualize_ascii", 0))
 end
-
-
 
 """
 Suggested function to print AbstractSystem objects to screen
@@ -79,7 +78,7 @@ function show_system(io::IO, ::MIME"text/plain", system::AbstractSystem{D}) wher
         extra_line = true
         @printf io "    %-17s : %s\n" string(k) string(v)
     end
-    if length(system) ≤ show_preferences().max_species_list
+    if length(system) ≤ show_preferences().max_particles_list
         extra_line && println(io)
         for atom in system
             println(io, "    ", atom)
@@ -87,7 +86,7 @@ function show_system(io::IO, ::MIME"text/plain", system::AbstractSystem{D}) wher
         extra_line = true
     end
 
-    if length(system) ≤ show_preferences().max_species_visualize_ascii
+    if length(system) ≤ show_preferences().max_particles_visualize_ascii
         ascii = visualize_ascii(system)
         if !isempty(ascii)
             extra_line && println(io)

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -2,7 +2,7 @@ using Printf
 using Preferences
 
 """
-Configures the default printing behaviour of `show_system`, which is invoked when a rich `text/htmal`
+Configures the printing behaviour of `show_system`, which is invoked when a rich `text/htmal`
 display of an `AbstractSystem` is requested. This is for example the case in a Julia REPL.
 The following options can be configured:
 
@@ -13,13 +13,18 @@ The following options can be configured:
 """
 function set_show_preferences!(; max_species_list=nothing, max_species_visualize_ascii=nothing)
     if !isnothing(max_species_list)
-        @set_preference!("max_species_list", max_species_list)
+        @set_preferences!("max_species_list" => max_species_list)
     end
     if !isnothing(max_species_visualize_ascii)
-        @set_preference!("max_species_visualize_ascii", max_species_visualize_ascii)
+        @set_preferences!("max_species_visualize_ascii" => max_species_visualize_ascii)
     end
     show_preferences()
 end
+
+"""
+Display the current printing behaviour of `show_system`.
+See [`set_show_preferences!](@ref) for more details on the keys.
+"""
 function show_preferences()
     (; max_species_list=@load_preference("max_species_list", 10),
        max_species_visualize_ascii=@load_preference("max_species_visualize_ascii", 0))
@@ -74,7 +79,7 @@ function show_system(io::IO, ::MIME"text/plain", system::AbstractSystem{D}) wher
         extra_line = true
         @printf io "    %-17s : %s\n" string(k) string(v)
     end
-    if length(system) < show_preferences().max_species_list
+    if length(system) ≤ show_preferences().max_species_list
         extra_line && println(io)
         for atom in system
             println(io, "    ", atom)
@@ -82,7 +87,7 @@ function show_system(io::IO, ::MIME"text/plain", system::AbstractSystem{D}) wher
         extra_line = true
     end
 
-    if length(system) < show_preferences().max_species_visualize_ascii
+    if length(system) ≤ show_preferences().max_species_visualize_ascii
         ascii = visualize_ascii(system)
         if !isempty(ascii)
             extra_line && println(io)

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -38,9 +38,9 @@ function show_system(io::IO, system::AbstractSystem{D}) where {D}
     pbc = periodicity(system)
     print(io, typeof(system).name.name, "($(chemical_formula(system))")
     perstr = [p ? "T" : "F" for p in pbc]
-    print(io, ", pbc = ", join(perstr, ""))
+    print(io, ", periodicity = ", join(perstr, ""))
 
-    if !any(pbc)
+    if any(pbc)
         box_str = ["[" * join(ustrip.(bvector), ", ") * "]"
                    for bvector in cell_vectors(system)]
         bunit = unit(eltype(first(cell_vectors(system))))
@@ -53,7 +53,7 @@ function show_system(io::IO, ::MIME"text/plain", system::AbstractSystem{D}) wher
     pbc  = periodicity(system)
     print(io, typeof(system).name.name, "($(chemical_formula(system))")
     perstr = [p ? "T" : "F" for p in periodicity(system)]
-    print(io, ", pbc = ", join(perstr, ""))
+    print(io, ", periodicity = ", join(perstr, ""))
     println(io, "):")
 
     extra_line = false

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -55,8 +55,7 @@ function show_system(io::IO, ::MIME"text/plain", system::AbstractSystem{D}) wher
         extra_line = true
     end
 
-    # TODO We will make this configurable in a follow-up PR
-    show_ascii = false
+    show_ascii = length(system) > @load_preference("system_visualize_ascii_max_atoms", 10)
     if show_ascii
         ascii = visualize_ascii(system)
         if !isempty(ascii)

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -2,12 +2,12 @@ using Printf
 using Preferences
 
 """
-Configures the printing behaviour of `show_system`, which is invoked when a rich `text/htmal`
+Configures the printing behaviour of `show_system`, which is invoked when a rich `text/plain`
 display of an `AbstractSystem` is requested. This is for example the case in a Julia REPL.
 The following options can be configured:
 
-- `max_species_list`: Maximal number of species in a system to trigger a listing of every species
-   along with its Cartesian positions. Default 10
+- `max_species_list`: Maximal number of species in a system (`length(system)`) to trigger a
+   listing of every species along with its Cartesian positions. Default 10
 - `max_species_visualize_ascii`: Maximal number of species in a system to trigger a representation
    in the form of an ascii cartoon using `visualize_ascii`. Default 0, i.e. diseabled.
 """

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -22,7 +22,7 @@ using Test
 end
 
 @testset "Printing atomic systems" begin
-    at = Atom(:Si, zeros(3) * u"m", zeros(3)u"m/s"; extradata=42)
+    at = Atom(:Si, zeros(3) * u"m", ones(3)u"m/s"; extradata=42)
     show(stdout, MIME("text/plain"), at)
     box = tuple([[10, 0.0, 0.0], [0.0, 5, 0.0], [0.0, 0.0, 7]]u"bohr" ...)
     flexible_system = periodic_system([at], box)

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -12,11 +12,11 @@ using Test
     box = tuple([[10, 0.0, 0.0], [0.0, 5, 0.0], [0.0, 0.0, 7]]u"bohr" ...)
 
     flexible_system = periodic_system(atoms, box; fractional=true, data=-12)
-    @test repr(flexible_system) == """FlexibleSystem(CSi, periodicity = TTT, bounding_box = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
+    @test repr(flexible_system) == """FlexibleSystem(CSi, periodicity = TTT, cell_vectors = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
     show(stdout, MIME("text/plain"), flexible_system)
 
     fast_system = FastSystem(flexible_system)
-    @test repr(fast_system) == """FastSystem(CSi, periodicity = TTT, bounding_box = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
+    @test repr(fast_system) == """FastSystem(CSi, periodicity = TTT, cell_vectors = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
     show(stdout, MIME("text/plain"), fast_system)
     show(stdout, MIME("text/plain"), fast_system[1])
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -12,17 +12,21 @@ using Test
     box = tuple([[10, 0.0, 0.0], [0.0, 5, 0.0], [0.0, 0.0, 7]]u"bohr" ...)
 
     flexible_system = periodic_system(atoms, box; fractional=true, data=-12)
-    @test repr(flexible_system) == "FlexibleSystem(CSi, pbc = TTT)"
-    # TODO:  I'm not sure why the expended expression should be printed in 
-    #        this setting. Still needs to be looked at please; same below 
-    # FlexibleSystem(CSi, pbc = TTT, cell_vectors = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
+    @test repr(flexible_system) == """FlexibleSystem(CSi, periodicity = TTT, bounding_box = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
     show(stdout, MIME("text/plain"), flexible_system)
 
     fast_system = FastSystem(flexible_system)
-    @test repr(fast_system) == "FastSystem(CSi, pbc = TTT)"
-    # FastSystem(CSi, periodic = TTT, cell_vectors = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")
+    @test repr(fast_system) == """FastSystem(CSi, periodicity = TTT, bounding_box = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
     show(stdout, MIME("text/plain"), fast_system)
     show(stdout, MIME("text/plain"), fast_system[1])
+end
+
+@testset "Printing atomic systems" begin
+    at = Atom(:Si, zeros(3) * u"m", zeros(3)u"m/s"; extradata=42)
+    show(stdout, MIME("text/plain"), at)
+    box = tuple([[10, 0.0, 0.0], [0.0, 5, 0.0], [0.0, 0.0, 7]]u"bohr" ...)
+    flexible_system = periodic_system([at], box)
+    show(stdout, MIME("text/plain"), flexible_system)
 end
 
 @testset "Test ASCII representation of structures" begin
@@ -45,7 +49,7 @@ end
     @testset "3D with negative unit cell" begin
         atoms = [:Si => [0.75, 0.75, 0.75],
                  :Si => [0.0,  0.0,  0.0]]
-        box = tuple([[-2.73, -2.73, 0.0], [-2.73, 0.0, -2.73], [0.0, -2.73, -2.73]]u"Å" ...) 
+        box = tuple([[-2.73, -2.73, 0.0], [-2.73, 0.0, -2.73], [0.0, -2.73, -2.73]]u"Å" ...)
         system = periodic_system(atoms, box; fractional=true)
         println(visualize_ascii(system))
     end


### PR DESCRIPTION
Follow-up to #121 to discuss ascii visualisation preferences. Ping @cortner @rkurchin @jgreener64 to get some opinions.

I personally find it quite convenient to automatically get this insight when working in the REPL or a notebook, but this may just be me. I also found it helps students ... but again I introduced it, so I'm biased.

Options in my opinion are:
- Don't do it, people have to do it by calling `visualize_ascii` manually each time. Pros: Clear what happens, least complexity; Cons: It's an extra function to learn for something where Julia has builtin mechanics.
- Use some preference to configure it, e.g. Just enable/disable, some threshold in terms of number of atoms (done right now) or some threshold in terms of "density" of atoms on the canvas (to avoid cluttered ascii art, which is useless); Pros: Everyone can do as they please, if properly documented with helper functions should be fairly intuitive; Cons: We have to agree on defaults because most people will not change them.

In fact there may even be some builtin show preferences in Julia one can use for the second point ... I vaguely remember that, but I have not checked.

Other thoughts ?