### PR TITLE
Include some special casing for chemical species

### DIFF
--- a/test/properties.jl
+++ b/test/properties.jl
@@ -24,7 +24,7 @@ end
     s3 = ChemicalSpecies(:D) 
     @test atomic_number(s3) == 1
     @test element_symbol(s3) == :H
-    @test s3.nneut == 1
+    @test s3.n_neutrons == 1
 end 
 
 @testset "Chemical formula with system" begin

--- a/test/species.jl
+++ b/test/species.jl
@@ -1,4 +1,3 @@
-
 using AtomsBase
 using Unitful
 using UnitfulAtomic
@@ -6,28 +5,41 @@ using Test
 
 ##
 
-@testset "ChemicalSpecies" begin 
+@testset "ChemicalSpecies" begin
+    @testset "Neutron determination" begin
+        symbols = [:H, :He, :Li, :Be, :B, :C, :N, :O, :F, :Ne,
+                  :Na, :Mg, :Al, :Si, :P, :S, :Cl, :Ar, :K, :Ca]
 
-symbols = [:H, :He, :Li, :Be, :B, :C, :N, :O, :F, :Ne, 
-          :Na, :Mg, :Al, :Si, :P, :S, :Cl, :Ar, :K, :Ca]
+        # https://thechemicalelements.com/protons-neutrons-electrons-of-elements/
+        n_neut =  [0, 2, 4, 5, 6, 6, 7, 8, 10, 10,
+                   12, 12, 14, 14, 16, 16, 18, 22, 20, 20]
 
-# https://thechemicalelements.com/protons-neutrons-electrons-of-elements/
-n_neut =  [0, 2, 4, 5, 6, 6, 7, 8, 10, 10, 
-           12, 12, 14, 14, 16, 16, 18, 22, 20, 20] 
+        for z = 1:10
+           @test ChemicalSpecies(symbols[z]) == ChemicalSpecies(z)
+           @test ChemicalSpecies(z) == ChemicalSpecies(z, n_neut[z], 0)
+        end
 
-for z = 1:10
-   @test ChemicalSpecies(symbols[z]) == ChemicalSpecies(z) == ChemicalSpecies(z, n_neut[z], 0)
-end
+        @test ChemicalSpecies(:D) == ChemicalSpecies(1, 1, 0)
+        @test ChemicalSpecies(:C13) == ChemicalSpecies(6, 7, 0)
+    end
 
-@test ChemicalSpecies(:D) == ChemicalSpecies(1, 1, 0)
-@test ChemicalSpecies(:C13) == ChemicalSpecies(6, 7, 0)
+    @testset "Printing" begin
+        @test "$(ChemicalSpecies(:O))" == "$(ChemicalSpecies(8))" == "O"
+        @test "$(ChemicalSpecies(8, 8, 0))" == "O"
+        @test "$(ChemicalSpecies(:C; n_neutrons=6))" == "C"
+        @test "$(ChemicalSpecies(:C; n_neutrons=7))" == "C13"
+    end
 
-@test atomic_number( UInt(8) ) == 8
-@test atomic_number( Int16(12) ) == 12
+    @testset "Special cases" begin
+        # Test a few special cases that come up in the wild
+        x = ChemicalSpecies(0)
+        @test x.n_neutrons == 0
+        @test atomic_number(x) == 0
+        @test mass(x) == 0u"u"
 
-@test "$(ChemicalSpecies(:O))" == "$(ChemicalSpecies(8))" == "O"
-@test "$(ChemicalSpecies(8, 8, 0))" == "O"
-@test "$(ChemicalSpecies(:C; n_neutrons=6))" == "C"
-@test "$(ChemicalSpecies(:C; n_neutrons=7))" == "C13"
+        @test x = ChemicalSpecies(:X)
+    end
 
+    @test atomic_number( UInt(8) ) == 8
+    @test atomic_number( Int16(12) ) == 12
 end

--- a/test/species.jl
+++ b/test/species.jl
@@ -37,7 +37,7 @@ using Test
         @test atomic_number(x) == 0
         @test mass(x) == 0u"u"
 
-        @test x = ChemicalSpecies(:X)
+        @test x == ChemicalSpecies(:X)
     end
 
     @test atomic_number( UInt(8) ) == 8


### PR DESCRIPTION
Adds a few more special cases to the handling of chemical species plus a bit of cleanup.

`:X` is fairly common in atomic structure files as a "dummy atom" with atomic number `0`. We can either force everyone to drop such atoms before using our stuff or include support here.

Here I am proposing to add this special case along with `:T` for tritium.

Note that I'm changing the Z -> data cache from an array to a Dict. Not sure if that has big performance implications, one could also handle this differently. @cortner probably knows if this may be an issue.