### PR TITLE
Rename bounding_box to cell_vectors consistently

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsBase"
 uuid = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 authors = ["JuliaMolSim community"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -23,8 +23,8 @@ ChemicalSpecies
 ## System properties
 
 ```@docs
-bounding_box
-set_bounding_box!
+cell_vectors
+set_cell_vectors!
 periodicity
 set_periodicity!
 cell 

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -45,14 +45,14 @@ A system is specified by a computational cell and particles within that cell (or
 - [`AtomsBase.cell(system)](@ref) : returns an object `cell` that specifies the computational cell. Two reference implementations, [`PeriodicCell`](@ref) and [`IsolatedCell`](@ref) that should serve most purposes are provided. 
 
 A cell object must implement methods for the following functions: 
-- [`AtomsBase.bounding_box(cell)`](@ref) : returns `NTuple{D, SVector{D, T}}` the cell vectors that specify the computational domain if it is finite. For isolated systems, the return values are unspecified.
-- [`AtomsBase.periodicity(cell)`](@ref) : returns `NTuple{D, Bool}`, booleans that specify whether the system is periodic in the direction of the `D` cell vectors provided by `bounding_box`. For isolated systems `periodicity` must return `(false, ..., false)`.
+- [`AtomsBase.cell_vectors(cell)`](@ref) : returns `NTuple{D, SVector{D, T}}` the cell vectors that specify the computational domain if it is finite. For isolated systems, the return values are unspecified.
+- [`AtomsBase.periodicity(cell)`](@ref) : returns `NTuple{D, Bool}`, booleans that specify whether the system is periodic in the direction of the `D` cell vectors provided by `cell_vectors`. For isolated systems `periodicity` must return `(false, ..., false)`.
 - [`AtomsBase.n_dimensions(cell)`](@ref) : returns the dimensionality of the computational cell, it must match the dimensionality of the system. 
 
 
-AtomsBase provides `bounding_box` and `periodicity` methods so that they can be called with a system as argument, i.e., 
+AtomsBase provides `cell_vectors` and `periodicity` methods so that they can be called with a system as argument, i.e., 
 ```julia
-bounding_box(system) = bounding_box(cell(system))
+cell_vectors(system) = cell_vectors(cell(system))
 periodicity(system)  =  periodicity(cell(system))
 ```
 
@@ -95,7 +95,7 @@ The optional setter / mutation interface consists of the following functions to 
 - [`set_position!(system, i, x)`](@ref) 
 - [`set_mass!(system, i, x)`](@ref)
 - [`set_species!(system, i, x)`](@ref) 
-- [`set_bounding_box!(cell, bb)`](@ref) 
+- [`set_cell_vectors!(cell, bb)`](@ref) 
 - [`set_periodicity!(cell, pbc)`](@ref) 
 - `deleteat!(system, i)` : delete atoms `i` (or atoms `i` if a list of `":`)
 - `append!(system1, system2)` : append system 2 to system 1, provided they are "compatible". 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -167,7 +167,7 @@ An update constructor for systems is supported as well (see [`AbstractSystem`](@
 ````@example system
 using AtomsBase: AbstractSystem
 AbstractSystem(hydrogen; 
-               bounding_box=([5.0, 0.0, 0.0]u"Å", 
+               cell_vectors=([5.0, 0.0, 0.0]u"Å", 
                              [0.0, 5.0, 0.0]u"Å", 
                              [0.0, 0.0, 5.0]u"Å"))
 ````
@@ -182,7 +182,7 @@ implementing the `AbstractSystem` interface.
 Similar to the atoms, system objects similarly support a functional-style access to system properties
 as well as a dict-style access:
 ````@example system
-bounding_box(hydrogen)
+cell_vectors(hydrogen)
 ````
 ````@example system
 hydrogen[:periodicity]
@@ -214,19 +214,19 @@ for some standard atomic system setups.
 For example to setup a hydrogen system with periodic BCs, we can issue
 ````@example
 using Unitful, UnitfulAtomic, AtomsBase  # hide
-bounding_box = ([10.0, 0.0, 0.0]u"Å", [0.0, 10.0, 0.0]u"Å", [0.0, 0.0, 10.0]u"Å")
+cell_vectors = ([10.0, 0.0, 0.0]u"Å", [0.0, 10.0, 0.0]u"Å", [0.0, 0.0, 10.0]u"Å")
 hydrogen = periodic_system([:H => [0, 0, 1.]u"Å",
                             :H => [0, 0, 3.]u"Å"],
-                           bounding_box)
+                           cell_vectors)
 ````
 To setup a silicon unit cell we can use fractional coordinates
 (which is common for solid-state simulations):
 ````@example
 using Unitful, UnitfulAtomic, AtomsBase  # hide
-bounding_box = 10.26 / 2 .*  ([0, 0, 1]u"bohr", [1, 0, 1]u"bohr", [1, 1, 0]u"bohr")
+cell_vectors = 10.26 / 2 .*  ([0, 0, 1]u"bohr", [1, 0, 1]u"bohr", [1, 1, 0]u"bohr")
 silicon = periodic_system([:Si =>  ones(3)/8,
                            :Si => -ones(3)/8],
-                           bounding_box, fractional=true)
+                           cell_vectors, fractional=true)
 ````
 Alternatively we can also place an isolated H2 molecule in vacuum, which is the standard setup for molecular simulations:
 ````@example

--- a/lib/AtomsBaseTesting/Project.toml
+++ b/lib/AtomsBaseTesting/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsBaseTesting"
 uuid = "ed7c10db-df7e-4efa-a7be-4f4190f7f227"
 authors = ["JuliaMolSim community"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
@@ -11,7 +11,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
-AtomsBase = "0.4"
+AtomsBase = "0.5"
 Unitful = "1"
 UnitfulAtomic = "1"
 julia = "1.6"

--- a/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
+++ b/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
@@ -94,7 +94,7 @@ function test_approx_eq(s::AbstractSystem, t::AbstractSystem;
 
         if s[prop] isa Quantity
             @test rnorm(s[prop], t[prop]) < rtol
-        elseif prop in (:bounding_box, ) && (cell(s) isa PeriodicCell)
+        elseif prop in (:cell_vectors, ) && (cell(s) isa PeriodicCell)
             @test maximum(map(rnorm, s[prop], t[prop])) < rtol
         else
             @test s[prop] == t[prop]
@@ -144,7 +144,7 @@ function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
         :magnetic_moment => [0.0, 0.0, 1.0, -1.0, 0.0],
     )
     sysprop = Dict{Symbol,Any}(
-        :bounding_box => box,
+        :cell_vectors => box,
         :periodicity  => (true, true, false),
         #
         :extra_data   => 42,
@@ -169,15 +169,15 @@ function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
             Atom(atprop[:species][i], atprop[:position][i]; atargs...)
         end
     end
-    cell = PeriodicCell(; bounding_box=sysprop[:bounding_box],
+    cell = PeriodicCell(; cell_vectors=sysprop[:cell_vectors],
                           periodicity=sysprop[:periodicity])
 
     sysargs = Dict(k => v for (k, v) in pairs(sysprop)
-                   if !(k in (:bounding_box, :periodicity)))
+                   if !(k in (:cell_vectors, :periodicity)))
     system = FlexibleSystem(atoms, cell; sysargs...)
 
     (; system, atoms, cell,
-     bounding_box=sysprop[:bounding_box], periodicity=sysprop[:periodicity],
+     cell_vectors=sysprop[:cell_vectors], periodicity=sysprop[:periodicity],
        atprop=NamedTuple(atprop), sysprop=NamedTuple(sysprop))
 end
 

--- a/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
+++ b/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
@@ -169,7 +169,7 @@ function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
             Atom(atprop[:species][i], atprop[:position][i]; atargs...)
         end
     end
-    cell = PeriodicCell(; cell_vectors=sysprop[:bounding_box],
+    cell = PeriodicCell(; bounding_box=sysprop[:bounding_box],
                           periodicity=sysprop[:periodicity])
 
     sysargs = Dict(k => v for (k, v) in pairs(sysprop)

--- a/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
+++ b/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
@@ -73,7 +73,7 @@ function test_approx_eq(s::AbstractSystem, t::AbstractSystem;
 
     # Test some things on cell objects
     if cell(s) isa PeriodicCell
-        @test maximum(map(rnorm, bounding_box(cell(s)), bounding_box(cell(t)))) < rtol
+        @test maximum(map(rnorm, cell_vectors(cell(s)), cell_vectors(cell(t)))) < rtol
     end
     @test periodicity(cell(s))  == periodicity(cell(t))
     @test n_dimensions(cell(s)) == n_dimensions(cell(t))

--- a/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
+++ b/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
@@ -179,8 +179,10 @@ function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
     system = FlexibleSystem(atoms, cell; sysargs...)
 
     (; system, atoms, cell,
-     cell_vectors=sysprop[:cell_vectors], periodicity=sysprop[:periodicity],
-       atprop=NamedTuple(atprop), sysprop=NamedTuple(sysprop))
+       cell_vectors=sysprop[:cell_vectors],
+       periodicity=sysprop[:periodicity],
+       atoms_properties=NamedTuple(atprop),
+       system_properties=NamedTuple(sysprop))
 end
 
 end

--- a/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
+++ b/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
@@ -181,8 +181,8 @@ function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
     (; system, atoms, cell,
        cell_vectors=sysprop[:cell_vectors],
        periodicity=sysprop[:periodicity],
-       atoms_properties=NamedTuple(atprop),
-       system_properties=NamedTuple(sysprop))
+       atprop=NamedTuple(atprop),
+       sysprop=NamedTuple(sysprop))
 end
 
 end

--- a/lib/AtomsBaseTesting/test/runtests.jl
+++ b/lib/AtomsBaseTesting/test/runtests.jl
@@ -15,30 +15,30 @@ include("testmacros.jl")
             @test sort(collect(keys(case.atprop)))  == sort(collect(atomkeys(case.system)))
             @test sort(collect(keys(case.atprop)))  == sort(collect(keys(case.atoms[1])))
             @test sort(collect(keys(case.sysprop))) == sort(collect(keys(case.system)))
-            @test case.bounding_box  == bounding_box(case.system)
+            @test case.cell_vectors  == cell_vectors(case.system)
             @test case.periodicity   == periodicity(case.system)
         end
 
         let case = make_test_system(; cellmatrix=:full)
-            box = reduce(hcat, bounding_box(case.system))
+            box = reduce(hcat, cell_vectors(case.system))
             @test UpperTriangular(box) != box
             @test LowerTriangular(box) != box
             @test Diagonal(box) != box
         end
         let case = make_test_system(; cellmatrix=:upper_triangular)
-            box = reduce(hcat, bounding_box(case.system))
+            box = reduce(hcat, cell_vectors(case.system))
             @test UpperTriangular(box) == box
             @test LowerTriangular(box) != box
             @test Diagonal(box) != box
         end
         let case = make_test_system(; cellmatrix=:lower_triangular)
-            box = reduce(hcat, bounding_box(case.system))
+            box = reduce(hcat, cell_vectors(case.system))
             @test UpperTriangular(box) != box
             @test LowerTriangular(box) == box
             @test Diagonal(box) != box
         end
         let case = make_test_system(; cellmatrix=:diagonal)
-            box = reduce(hcat, bounding_box(case.system))
+            box = reduce(hcat, cell_vectors(case.system))
             @test Diagonal(box) == box
             @test UpperTriangular(box) == box
             @test LowerTriangular(box) == box
@@ -63,7 +63,7 @@ include("testmacros.jl")
         case = make_test_system()
         system = case.system
         atoms  = case.atoms
-        box    = case.bounding_box
+        box    = case.cell_vectors
         bcs    = case.periodicity
         sysprop = case.sysprop
         # end simplify
@@ -82,7 +82,7 @@ include("testmacros.jl")
         case = make_test_system()
         system = case.system
         atoms  = case.atoms
-        box    = case.bounding_box
+        box    = case.cell_vectors
         bcs    = case.periodicity
         sysprop = case.sysprop
         # end simplify

--- a/src/implementation/fast_system.jl
+++ b/src/implementation/fast_system.jl
@@ -16,10 +16,10 @@ struct FastSystem{D, TCELL, L <: Unitful.Length, M <: Unitful.Mass, S} <: Abstra
 end
 
 # Constructor to fetch the types
-function FastSystem(box::AUTOBOX, 
-                    pbc::AUTOPBC, 
+function FastSystem(cell_vectors::AUTOCELL,
+                    periodicity::AUTOPBC,
                     positions, species, masses)
-    cϵll = PeriodicCell(; bounding_box = box, periodicity = pbc)
+    cϵll = PeriodicCell(; cell_vectors, periodicity)
     FastSystem(cϵll, positions, species, masses)
 end 
 
@@ -40,8 +40,8 @@ function FastSystem(system::AbstractSystem)
 end
 
 # Convenience constructor where we don't have to preconstruct all the static stuff...
-function FastSystem(particles, box::AUTOBOX, pbc::AUTOPBC)
-    box1 = _auto_bounding_box(box)
+function FastSystem(particles, cell_vectors::AUTOCELL, pbc::AUTOPBC)
+    box1 = _auto_cell_vectors(cell_vectors)
     pbc1 = _auto_pbc(pbc, box1)
     D = length(box1)
     if !all(length.(box1) .== D)
@@ -66,16 +66,16 @@ Base.getindex(sys::FastSystem, i::Integer)  = AtomView(sys, i)
 
 # System property access
 function Base.getindex(system::FastSystem, x::Symbol)
-    if x === :bounding_box
-        bounding_box(system)
+    if x === :cell_vectors
+        cell_vectors(system)
     elseif x === :periodicity
         periodicity(system)
     else
         throw(KeyError(x))
     end
 end
-Base.haskey(::FastSystem, x::Symbol) = x in (:bounding_box, :periodicity)
-Base.keys(::FastSystem) = (:bounding_box, :periodicity)
+Base.haskey(::FastSystem, x::Symbol) = x in (:cell_vectors, :periodicity)
+Base.keys(::FastSystem) = (:cell_vectors, :periodicity)
 
 # Atom and atom property access
 atomkeys(::FastSystem) = (:position, :species, :mass)

--- a/src/implementation/fast_system.jl
+++ b/src/implementation/fast_system.jl
@@ -19,7 +19,7 @@ end
 function FastSystem(box::AUTOBOX, 
                     pbc::AUTOPBC, 
                     positions, species, masses)
-    cϵll = PeriodicCell(; cell_vectors = box, periodicity = pbc)
+    cϵll = PeriodicCell(; bounding_box = box, periodicity = pbc)
     FastSystem(cϵll, positions, species, masses)
 end 
 
@@ -41,7 +41,7 @@ end
 
 # Convenience constructor where we don't have to preconstruct all the static stuff...
 function FastSystem(particles, box::AUTOBOX, pbc::AUTOPBC)
-    box1 = _auto_cell_vectors(box)
+    box1 = _auto_bounding_box(box)
     pbc1 = _auto_pbc(pbc, box1)
     D = length(box1)
     if !all(length.(box1) .== D)

--- a/src/implementation/flexible_system.jl
+++ b/src/implementation/flexible_system.jl
@@ -54,7 +54,7 @@ function FlexibleSystem(
         pbc::AUTOPBC{D};
         kwargs...
     ) where {S, D}
-    cϵll = PeriodicCell(; cell_vectors = box, periodicity = pbc)
+    cϵll = PeriodicCell(; bounding_box = box, periodicity = pbc)
     FlexibleSystem{D, S, typeof(cϵll)}(particles, cϵll, Dict(kwargs...))
 end
 

--- a/src/implementation/flexible_system.jl
+++ b/src/implementation/flexible_system.jl
@@ -16,8 +16,8 @@ cell(sys::FlexibleSystem) = sys.cell
 
 # System property access
 function Base.getindex(system::FlexibleSystem, x::Symbol)
-    if x === :bounding_box
-        bounding_box(system)
+    if x === :cell_vectors
+        cell_vectors(system)
     elseif x === :periodicity
         periodicity(system)
     else
@@ -26,10 +26,10 @@ function Base.getindex(system::FlexibleSystem, x::Symbol)
 end
 
 function Base.haskey(system::FlexibleSystem, x::Symbol)
-    x in (:bounding_box, :periodicity) || haskey(system.data, x)
+    x in (:cell_vectors, :periodicity) || haskey(system.data, x)
 end
 
-Base.keys(system::FlexibleSystem) = (:bounding_box, :periodicity, keys(system.data)...)
+Base.keys(system::FlexibleSystem) = (:cell_vectors, :periodicity, keys(system.data)...)
 
 # Atom and atom property access
 Base.getindex(system::FlexibleSystem, i::Integer) = system.particles[i]
@@ -41,8 +41,8 @@ Base.getindex(system::FlexibleSystem, ::Colon, x::Symbol) = [at[x] for at in sys
 
 
 """
-    FlexibleSystem(particles, bounding_box, periodicity; kwargs...)
-    FlexibleSystem(particles; bounding_box, periodicity, kwargs...)
+    FlexibleSystem(particles, cell_vectors, periodicity; kwargs...)
+    FlexibleSystem(particles; cell_vectors, periodicity, kwargs...)
     FlexibleSystem(particles, cell; kwargs...)
 
 Construct a flexible system, a versatile data structure for atomistic systems,
@@ -50,16 +50,16 @@ which puts an emphasis on flexibility rather than speed.
 """
 function FlexibleSystem(
         particles::AbstractVector{S},
-        box::AUTOBOX{D},
-        pbc::AUTOPBC{D};
+        cell_vectors::AUTOCELL{D},
+        periodicity::AUTOPBC{D};
         kwargs...
     ) where {S, D}
-    cϵll = PeriodicCell(; bounding_box = box, periodicity = pbc)
+    cϵll = PeriodicCell(; cell_vectors, periodicity)
     FlexibleSystem{D, S, typeof(cϵll)}(particles, cϵll, Dict(kwargs...))
 end
 
-function FlexibleSystem(particles; bounding_box, periodicity, kwargs...)
-    FlexibleSystem(particles, bounding_box, periodicity; kwargs...)
+function FlexibleSystem(particles; cell_vectors, periodicity, kwargs...)
+    FlexibleSystem(particles, cell_vectors, periodicity; kwargs...)
 end
 
 function FlexibleSystem(particles::AbstractVector, cell; kwargs...) 
@@ -88,13 +88,13 @@ Update constructor. Construct a new system where one or more properties are chan
 which are given as `kwargs`. A subtype of `AbstractSystem` is returned, by default
 a `FlexibleSystem`, but depending on the type of the passed system this might differ.
 
-Supported `kwargs` include `particles`, `atoms`, `bounding_box` and `periodicity`
+Supported `kwargs` include `particles`, `atoms`, `cell_vectors` and `periodicity`
 as well as user-specific custom properties.
 
 # Examples
 Change the bounding box and the atoms of the passed system
 ```julia-repl
-julia> AbstractSystem(system; bounding_box= ..., atoms = ... )
+julia> AbstractSystem(system; cell_vectors= ..., atoms = ... )
 ```
 """
 AbstractSystem(system::AbstractSystem; kwargs...) = FlexibleSystem(system; kwargs...)

--- a/src/implementation/utils.jl
+++ b/src/implementation/utils.jl
@@ -80,7 +80,7 @@ julia> silicon = periodic_system([:Si =>  ones(3)/8,
 function periodic_system(atoms::AbstractVector,
                          box::AUTOBOX;
                          fractional=false, kwargs...)
-    lattice = _auto_cell_vectors(box)
+    lattice = _auto_bounding_box(box)
     pbcs = fill(true, length(lattice))
     !fractional && return atomic_system(atoms, lattice, pbcs; kwargs...)
 

--- a/src/implementation/utils.jl
+++ b/src/implementation/utils.jl
@@ -7,7 +7,7 @@
 export atomic_system, isolated_system, periodic_system
 
 """
-    atomic_system(atoms::AbstractVector, bounding_box, periodicity; kwargs...)
+    atomic_system(atoms::AbstractVector, cell_vectors, periodicity; kwargs...)
 
 Construct a [`FlexibleSystem`](@ref) using the passed `atoms` and boundary box and conditions.
 Extra `kwargs` are stored as custom system properties.
@@ -15,11 +15,11 @@ Extra `kwargs` are stored as custom system properties.
 # Examples
 Construct a hydrogen molecule in a box, which is periodic only in the first two dimensions
 ```julia-repl
-julia> bounding_box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+julia> cell_vectors = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
 julia> pbcs = (true, true, false)
 julia> hydrogen = atomic_system([:H => [0, 0, 1.]u"bohr",
                                  :H => [0, 0, 3.]u"bohr"],
-                                  bounding_box, pbcs)
+                                  cell_vectors, pbcs)
 ```
 """
 atomic_system(atoms::AbstractVector{<:Atom}, box, pbcs; kwargs...) = 
@@ -63,10 +63,10 @@ Extra `kwargs` are stored as custom system properties.
 # Examples
 Setup a hydrogen molecule inside periodic BCs:
 ```julia-repl
-julia> bounding_box = ([10.0, 0.0, 0.0]u"Å", [0.0, 10.0, 0.0]u"Å", [0.0, 0.0, 10.0]u"Å")
+julia> cell_vectors = ([10.0, 0.0, 0.0]u"Å", [0.0, 10.0, 0.0]u"Å", [0.0, 0.0, 10.0]u"Å")
 julia> hydrogen = periodic_system([:H => [0, 0, 1.]u"bohr",
                                    :H => [0, 0, 3.]u"bohr"],
-                                  bounding_box)
+                                  cell_vectors)
 ```
 
 Setup a silicon unit cell using fractional positions
@@ -78,9 +78,9 @@ julia> silicon = periodic_system([:Si =>  ones(3)/8,
 ```
 """
 function periodic_system(atoms::AbstractVector,
-                         box::AUTOBOX;
+                         cell::AUTOCELL;
                          fractional=false, kwargs...)
-    lattice = _auto_bounding_box(box)
+    lattice = _auto_cell_vectors(cell)
     pbcs = fill(true, length(lattice))
     !fractional && return atomic_system(atoms, lattice, pbcs; kwargs...)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,7 +1,7 @@
 import Base.position
 import PeriodicTable
 
-export bounding_box,
+export cell_vectors,
        periodicity,
        cell,
        n_dimensions,
@@ -34,24 +34,24 @@ abstract type AbstractSystem{D} end
 
 
 """
-    bounding_box(sys::AbstractSystem{D})
+    cell_vectors(sys::AbstractSystem{D})
 
-Return a tuple of length `D` of vectors of length `D` that describe the 
-"box" in which the system `sys` is defined.
+Return a tuple of length `D` of vectors of length `D` that describe the
+cell in which the system `sys` is defined.
 """
-function bounding_box end
+function cell_vectors end
 
 """
-    set_bounding_box!(sys::AbstractSystem{D}, bb::NTuple{D, SVector{D, L}})
+    set_cell_vectors!(sys::AbstractSystem{D}, bb::NTuple{D, SVector{D, L}})
 """
-function set_bounding_box! end
+function set_cell_vectors! end
 
 
 """
     periodicity(sys::AbstractSystem{D})
 
 Return a `NTuple{D, Bool}` indicating whether the system is periodic along a
-cell vector as specified by `bounding_box`.
+cell vector as specified by `cell_vectors`.
 """
 function periodicity end 
 
@@ -169,7 +169,7 @@ n_dimensions(::AbstractSystem{D}) where {D} = D
 
 #  interface functions to connect Systems and cells 
 
-bounding_box(system::AbstractSystem) = bounding_box(cell(system))
+cell_vectors(system::AbstractSystem) = cell_vectors(cell(system))
 
 periodicity(system::AbstractSystem) = periodicity(cell(system))
 

--- a/src/utils/atomview.jl
+++ b/src/utils/atomview.jl
@@ -13,8 +13,8 @@ See [FastSystem](@ref Struct-of-Arrays-/-FastSystem) for an example of system
 using `AtomView` as its species type.
 
 ## Example
-```jldoctest; setup=:(using AtomsBase, Unitful; atoms = Atom[:C => [0.25, 0.25, 0.25]u"Å", :C => [0.75, 0.75, 0.75]u"Å"]; box = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]u"Å"; boundary_conditions = [Periodic(), Periodic(), DirichletZero()])
-julia> system = FastSystem(atoms, box, boundary_conditions);
+```jldoctest; setup=:(using AtomsBase, Unitful; atoms = Atom[:C => [0.25, 0.25, 0.25]u"Å", :C => [0.75, 0.75, 0.75]u"Å"]; cell_vectorn = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]u"Å"; boundary_conditions = [Periodic(), Periodic(), DirichletZero()])
+julia> system = FastSystem(atoms, cell_vectorn, boundary_conditions);
 
 julia> atom = system[2]
 AtomView(C, atomic_number = 6, mass = 12.011 u):

--- a/src/utils/cells.jl
+++ b/src/utils/cells.jl
@@ -50,9 +50,7 @@ n_dimensions(::PeriodicCell{D}) where {D} = D
 
 # kwarg constructor for PeriodicCell
 
-function PeriodicCell(; cell_vectors=nothing, periodicity, cell_vectors=nothing)
-    !isnothing(cell_vectors) && @warn "cell_vectors kwarg is deprecated and will be removed"
-    cell_vectors = something(cell_vectors, cell_vectors)
+function PeriodicCell(; cell_vectors=nothing, periodicity)
     PeriodicCell(_auto_cell_vectors(cell_vectors),
                  _auto_pbc(periodicity, cell_vectors))
 end

--- a/src/utils/show.jl
+++ b/src/utils/show.jl
@@ -11,9 +11,9 @@ function show_system(io::IO, system::AbstractSystem{D}) where {D}
 
     if !any(pbc)
         box_str = ["[" * join(ustrip.(bvector), ", ") * "]"
-                   for bvector in bounding_box(system)]
-        bunit = unit(eltype(first(bounding_box(system))))
-        print(io, ", bounding_box = [", join(box_str, ", "), "]u\"$bunit\"")
+                   for bvector in cell_vectors(system)]
+        bunit = unit(eltype(first(cell_vectors(system))))
+        print(io, ", cell_vectors = [", join(box_str, ", "), "]u\"$bunit\"")
     end
     print(io, ")")
 end
@@ -28,11 +28,11 @@ function show_system(io::IO, ::MIME"text/plain", system::AbstractSystem{D}) wher
     extra_line = false
     if any(pbc) 
         extra_line = true
-        box = bounding_box(system)
-        bunit = unit(eltype(first(bounding_box(system))))
+        box = cell_vectors(system)
+        bunit = unit(eltype(first(cell_vectors(system))))
         for (i, bvector) in enumerate(box)
             if i == 1
-                @printf io "    %-17s : [" "bounding_box"
+                @printf io "    %-17s : [" "cell_vectors"
             else
                 print(io, " "^25)
             end
@@ -43,7 +43,7 @@ function show_system(io::IO, ::MIME"text/plain", system::AbstractSystem{D}) wher
     end
 
     for (k, v) in pairs(system)
-        k in (:bounding_box, :periodicity) && continue
+        k in (:cell_vectors, :periodicity) && continue
         extra_line = true
         @printf io "    %-17s : %s\n" string(k) string(v)
     end

--- a/src/utils/visualize_ascii.jl
+++ b/src/utils/visualize_ascii.jl
@@ -13,10 +13,10 @@ function visualize_ascii(system::AbstractSystem{D}) where {D}
     # See output.py in the GPAW sources
 
     # Unit cell matrix (vectors column-by-column) and plotting box (xyz)
-    cell  = austrip.(reduce(hcat, bounding_box(system)))
+    cell  = austrip.(reduce(hcat, cell_vectors(system)))
     box   = Vector(diag(cell))
     shift = zero(box)
-    plot_box = D > 1
+    plot_cell = D > 1
 
     is_right_handed = det(cell) > 0
     is_right_handed || return ""
@@ -31,7 +31,7 @@ function visualize_ascii(system::AbstractSystem{D}) where {D}
         centre_atoms = austrip.(sum(position(system, :)) / length(system))
         shift = box / 2 - centre_atoms
 
-        plot_box = false
+        plot_cell = false
     end
 
     # If one of the box coordinates is negative
@@ -71,7 +71,7 @@ function visualize_ascii(system::AbstractSystem{D}) where {D}
     pos2d = [1 .+ round.(Int, projector * p .+ eps(Float64)) for p in normpos]
 
     # Draw box onto canvas
-    if plot_box
+    if plot_cell
         # 7 Corners:
         canvas[2      + sy, 1 + sy     ] = '.'
         canvas[2 + sx + sy, 1 + sy     ] = '.'

--- a/test/fast_system.jl
+++ b/test/fast_system.jl
@@ -15,11 +15,11 @@ using StaticArrays
     @test size(system)   == (2, )
     @test mass(system, :) == [12.011, 12.011]u"u"
     @test periodicity(system) == pbcs
-    @test bounding_box(system) == box
+    @test cell_vectors(system) == box
     @test system[:periodicity] == pbcs
-    @test system[:bounding_box] == box
+    @test system[:cell_vectors] == box
     @test element(system[1]) == element(:C)
-    @test keys(system) == (:bounding_box, :periodicity)
+    @test keys(system) == (:cell_vectors, :periodicity)
     @test haskey(system, :periodicity)
     @test system[:periodicity][1] == true
     @test atomkeys(system) == (:position, :species, :mass)
@@ -42,7 +42,7 @@ using StaticArrays
     @test !haskey(system[1], :abc)
     @test get(system[1], :dagger, 3) == 3
 
-    @test collect(pairs(system)) == [(:bounding_box => box), (:periodicity => pbcs)]
+    @test collect(pairs(system)) == [(:cell_vectors => box), (:periodicity => pbcs)]
     @test collect(pairs(system[1])) == [
         :position => position(atoms[1]),
         :species => ChemicalSpecies(:C),
@@ -52,7 +52,7 @@ using StaticArrays
     # check type stability
     # TODO: this test needs to be fixed, right now it just tests equality and not 
     #       type stability 
-    # get_b_vector(syst) = bounding_box(syst)[2]
+    # get_b_vector(syst) = cell_vectors(syst)[2]
     # @test @inferred(get_b_vector(system)) == SVector{3}([0.0, 1.0, 0.0]u"m")
     # @test @inferred(position(system, 1)) == SVector{3}([0.25, 0.25, 0.25]u"m")
     # @test ismissing(@inferred(velocity(system, 2)))

--- a/test/flexible_system.jl
+++ b/test/flexible_system.jl
@@ -29,14 +29,14 @@ using Test
     @test system[1:2, :mass]  == mass.([ChemicalSpecies(:Si), ChemicalSpecies(:C)])
     @test system[[1, 3], :mass]  == mass.([ChemicalSpecies(:Si), ChemicalSpecies(:H)])
     @test system[[false, true, true], :species] == ChemicalSpecies.([:C, :H])
-    @test system[:bounding_box] == box
+    @test system[:cell_vectors] == box
     @test atomkeys(system) == (:position, :velocity, :species, :mass)
     @test hasatomkey(system, :mass)
     @test !hasatomkey(system, :blubber)
     @test get(system, :blubber, :adidi) == :adidi
 
     @test collect(pairs(system)) == [
-        :bounding_box => box, :periodicity => pbcs,
+        :cell_vectors => box, :periodicity => pbcs,
         :extradata => 45, :dic => dic
     ]
     @test collect(pairs(system[1])) == [

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -28,7 +28,7 @@ using PeriodicTable
         @test length(flexible) == 2
         @test size(flexible)   == (2, )
 
-        @test bounding_box(flexible) == ([1, 0, 0]u"m", [0, 1, 0]u"m", [0, 0, 1]u"m")
+        @test cell_vectors(flexible) == ([1, 0, 0]u"m", [0, 1, 0]u"m", [0, 0, 1]u"m")
         @test periodicity(flexible) == (true, true, false)
         @test n_dimensions(flexible) == 3
         @test position(flexible, :) == [[0.25, 0.25, 0.25], [0.75, 0.75, 0.75]]u"m"

--- a/test/making_system.jl
+++ b/test/making_system.jl
@@ -32,9 +32,9 @@ using Test
         @test periodicity(system) == (true, true, true)
         @test cell(system) isa PeriodicCell
         @test position(system, :) == [[0.0, -0.625, 0.0], [1.25, 0.0, 0.0], [0.0, 0.0, 0.0]]u"Å"
-        @test bounding_box(system)[1] == box[1]
-        @test bounding_box(system)[2] == box[2]
-        @test bounding_box(system)[3] == box[3]
+        @test cell_vectors(system)[1] == box[1]
+        @test cell_vectors(system)[2] == box[2]
+        @test cell_vectors(system)[3] == box[3]
         @test system[:extradata] == 48
         @test system[:dic]["extradata_dic"] == "49"
     end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -15,12 +15,12 @@ using Test
     @test repr(flexible_system) == "FlexibleSystem(CSi, pbc = TTT)"
     # TODO:  I'm not sure why the expended expression should be printed in 
     #        this setting. Still needs to be looked at please; same below 
-    # FlexibleSystem(CSi, pbc = TTT, bounding_box = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
+    # FlexibleSystem(CSi, pbc = TTT, cell_vectors = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")"""
     show(stdout, MIME("text/plain"), flexible_system)
 
     fast_system = FastSystem(flexible_system)
     @test repr(fast_system) == "FastSystem(CSi, pbc = TTT)"
-    # FastSystem(CSi, periodic = TTT, bounding_box = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")
+    # FastSystem(CSi, periodic = TTT, cell_vectors = [[10.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 7.0]]u"a₀")
     show(stdout, MIME("text/plain"), fast_system)
     show(stdout, MIME("text/plain"), fast_system[1])
 end

--- a/test/test_docstrings.jl
+++ b/test/test_docstrings.jl
@@ -13,11 +13,11 @@ using Test
 # atomic_system docstring
 
 try 
-   bounding_box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+   cell_vectors = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
    pbcs = (true, true, false)
    hydrogen = atomic_system([:H => [0, 0, 1.]u"bohr",
                                  :H => [0, 0, 3.]u"bohr"],
-                                  bounding_box, pbcs)
+                                  cell_vectors, pbcs)
    @test true
 catch 
    @error("atomic_system docstring failed to run")
@@ -40,10 +40,10 @@ end
 # periodic_system docstring 1 
 
 try 
-   bounding_box = ([10.0, 0.0, 0.0]u"Å", [0.0, 10.0, 0.0]u"Å", [0.0, 0.0, 10.0]u"Å")
+   cell_vectors = ([10.0, 0.0, 0.0]u"Å", [0.0, 10.0, 0.0]u"Å", [0.0, 0.0, 10.0]u"Å")
    hydrogen = periodic_system([:H => [0, 0, 1.]u"bohr",
                                       :H => [0, 0, 3.]u"bohr"],
-                                     bounding_box)
+                                     cell_vectors)
    @test true 
 catch e 
    @error("periodic_system docstring 1 failed to run")


### PR DESCRIPTION
Renamed occurrences of cell_vectors to bounding_box for consistency.