### PR TITLE
AtomsBaseTesting cell vectors check for infinite systems

### DIFF
--- a/lib/AtomsBaseTesting/Project.toml
+++ b/lib/AtomsBaseTesting/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsBaseTesting"
 uuid = "ed7c10db-df7e-4efa-a7be-4f4190f7f227"
 authors = ["JuliaMolSim community"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
+++ b/lib/AtomsBaseTesting/src/AtomsBaseTesting.jl
@@ -72,11 +72,15 @@ function test_approx_eq(s::AbstractSystem, t::AbstractSystem;
     end
 
     # Test some things on cell objects
-    if cell(s) isa PeriodicCell
-        @test maximum(map(rnorm, cell_vectors(cell(s)), cell_vectors(cell(t)))) < rtol
-    end
     @test periodicity(cell(s))  == periodicity(cell(t))
     @test n_dimensions(cell(s)) == n_dimensions(cell(t))
+    if cell(s) isa PeriodicCell
+        for (dim, periodic) in enumerate(periodicity(cell(s)))
+            if periodic
+                @test rnorm(cell_vectors(cell(s))[dim], cell_vectors(cell(t))[dim]) < rtol
+            end
+        end
+    end
 
     # test properties of systems
     if common_only


### PR DESCRIPTION
Testing the cell vectors are equal can give `NaN` if `Inf` is used in non-periodic dimensions. This avoids checking non-periodic dimensions.