### PR TITLE
Bugfixes related to chemical_formula

### DIFF
--- a/src/utils/chemspecies.jl
+++ b/src/utils/chemspecies.jl
@@ -199,7 +199,7 @@ atomic_number(z::Integer) = z
 
 atomic_number(s::Symbol) = _sym2z[s]
 
-atomic_symbol(element::ChemicalSpecies) = element 
+atomic_symbol(element::ChemicalSpecies) = element
 
 Base.convert(::Type{Symbol}, element::ChemicalSpecies) = Symbol(element) 
 
@@ -248,11 +248,16 @@ Return the symbols corresponding to the elements of the atoms. Note that
 this may be different than `atomic_symbol` for cases where `atomic_symbol`
 is chosen to be more specific (i.e. designate a special atom).
 """
-element_symbol(sys::AbstractSystem, index) = 
+element_symbol(sys::AbstractSystem, index) =
         element_symbol.(sys[index])
 
-element_symbol(species) = 
+function element_symbol(species)
+    if atomic_number(species) == 0
+        :X
+    else
         Symbol(element(atomic_number(species)).symbol)
+    end
+end
 
 
 """
@@ -296,7 +301,7 @@ Defaults to [`atomic_symbol`](@ref), if `name` field is zero or not defined.
 """
 function atom_name(cs::ChemicalSpecies)
    if cs.name == 0
-       return atomic_symbol(cs)
+       return Symbol(atomic_symbol(cs))  # atomic_symbol is a ChemicalSpecies
    else
        # filter first empty space characters
        as_characters = Char.( reinterpret(SVector{4, UInt8}, [cs.name])[1] )

--- a/src/utils/properties.jl
+++ b/src/utils/properties.jl
@@ -17,5 +17,6 @@ function chemical_formula(symbols::AbstractVector{Symbol})
     join(sort(parts))
 end
 
-chemical_formula(system::AbstractSystem) = 
-        chemical_formula(element_symbol(system, :))
+function chemical_formula(system::AbstractSystem)
+    chemical_formula(Symbol.(atomic_symbol(system, :)))
+end

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -11,34 +11,33 @@ using UnitfulAtomic
     @test chemical_formula([:Ga, :N, :O, :H, :H]) == "GaH₂NO"
 end
 
-@testset "Chemical Species" begin 
+@testset "Chemical Species" begin
     s = ChemicalSpecies(:C)
     @test atomic_number(s) == 6
     @test atomic_symbol(s) == :C
     s1 = ChemicalSpecies(:C; n_neutrons=7)
-    s2 = ChemicalSpecies(:C13) 
+    s2 = ChemicalSpecies(:C13)
     @test s1 == s2
     @test atomic_number(s1) == 6
     @test atomic_symbol(s1) == :C13
 
-    s3 = ChemicalSpecies(:D) 
+    s3 = ChemicalSpecies(:D)
     @test atomic_number(s3) == 1
     @test element_symbol(s3) == :H
     @test s3.n_neutrons == 1
-end 
+end
 
 @testset "Chemical formula with system" begin
     lattice     = tuple([12u"bohr" * rand(3) for _ in 1:3]...)
-    atoms       = [Atom(:C13, randn(3)u"Å"), 
-                   Atom(:C14, randn(3)u"Å"), 
-                   Atom(:D, randn(3)u"Å" ),  
-                   Atom(:D, randn(3)u"Å" ),  
-                   Atom(:D, randn(3)u"Å" ),  
+    atoms       = [Atom(:C13, randn(3)u"Å"),
+                   Atom(:C14, randn(3)u"Å"),
+                   Atom(:D, randn(3)u"Å" ),
+                   Atom(:D, randn(3)u"Å" ),
+                   Atom(:D, randn(3)u"Å" ),
+                   Atom(:X, randn(3)u"Å" ),
                   ]
     system = periodic_system(atoms, lattice)
-    @test species(system, :) == ChemicalSpecies.([:C13, :C14, :D, :D, :D])
-    @test element_symbol(system, :) == [:C, :C, :H, :H, :H]
-    @test chemical_formula(system) == "C₂H₃"
+    @test species(system, :) == ChemicalSpecies.([:C13, :C14, :D, :D, :D, :X])
+    @test element_symbol(system, :) == [:C, :C, :H, :H, :H, :X]
+    @test chemical_formula(system) == "C13C14D₃X"
 end
-
-

--- a/test/species.jl
+++ b/test/species.jl
@@ -61,7 +61,7 @@ end
 @test mass(ChemicalSpecies(:C)) != mass(ChemicalSpecies(:C13))
 @test mass(ChemicalSpecies(:C12)) != mass(ChemicalSpecies(:C13))
 
-@test atom_name(ChemicalSpecies(:C)) == atomic_symbol(ChemicalSpecies(:C))
+@test atom_name(ChemicalSpecies(:C)) == Symbol(atomic_symbol(ChemicalSpecies(:C)))
 @test atom_name(ChemicalSpecies(:C; atom_name=:MyC)) == :MyC
 
 tmp = ChemicalSpecies(:C12; atom_name=:MyC)


### PR DESCRIPTION
Mostly bug fixes, main thing to discuss:

I'm not sure having `chemical_formula` not return isotope-specific symbols is the right thing to do. If I have non-standard isotope compositions I would annotate it in a formula, so I make this change (see tests).

Thoughts about that ? @cortner made the current implementation I believe.