### PR TITLE
Fix bug in element_symbol call

### DIFF
--- a/src/utils/chemspecies.jl
+++ b/src/utils/chemspecies.jl
@@ -249,7 +249,7 @@ this may be different than `atomic_symbol` for cases where `atomic_symbol`
 is chosen to be more specific (i.e. designate a special atom).
 """
 element_symbol(sys::AbstractSystem, index) = 
-        element_symbol.(sys[index])
+        element_symbol.(species(sys,index))
 
 element_symbol(species) = 
         Symbol(element(atomic_number(species)).symbol)

--- a/src/utils/chemspecies.jl
+++ b/src/utils/chemspecies.jl
@@ -248,8 +248,8 @@ Return the symbols corresponding to the elements of the atoms. Note that
 this may be different than `atomic_symbol` for cases where `atomic_symbol`
 is chosen to be more specific (i.e. designate a special atom).
 """
-element_symbol(sys::AbstractSystem, index) = 
-        element_symbol.(species(sys,index))
+element_symbol(sys::AbstractSystem, index) =
+        element_symbol.( species(sys, index) )
 
 element_symbol(species) = 
         Symbol(element(atomic_number(species)).symbol)

--- a/test/species.jl
+++ b/test/species.jl
@@ -105,6 +105,7 @@ tmp = ChemicalSpecies(:C12; atom_name=:MyC)
 
    @test element_symbol(system, 1) == :C
    @test element_symbol(system, 2) == :C
+   @test element_symbol(system, :) == [:C, :C]
 end
 
 end

--- a/test/species.jl
+++ b/test/species.jl
@@ -72,6 +72,9 @@ tmp = ChemicalSpecies(:C12; atom_name=:MyC)
 @test mass(ChemicalSpecies(:X)) == 0.0u"u"
 @test ismissing( mass(ChemicalSpecies(:H31)) )
 
+@test element_symbol(ChemicalSpecies(:C)) == :C
+@test element_symbol(ChemicalSpecies(:C13)) == :C
+
 @testset "ChemicalSpecies in Atom and FastSystem" begin
    box = ([1, 0, 0]u"m", [0, 1, 0]u"m", [0, 0, 1]u"m")
    pbcs = (true, true, false)
@@ -99,6 +102,9 @@ tmp = ChemicalSpecies(:C12; atom_name=:MyC)
 
    @test mass(system, 1) == mass(ChemicalSpecies(:C))
    @test mass(system, 2) == mass(ChemicalSpecies(:C12))
+
+   @test element_symbol(system, 1) == :C
+   @test element_symbol(system, 2) == :C
 end
 
 end


### PR DESCRIPTION
Currently this will fail

```julia
using AtomsBase
using Unitful

hydrogen = isolated_system([
               :H => [0, 0, 0.]u"Å",
               :H => [0, 0, 1.]u"Å"
           ])
element_symbol(hydrogen, 1)  # error
```

This PR fixes it.