### PR TITLE
fix #139

### DIFF
--- a/src/utils/chemspecies.jl
+++ b/src/utils/chemspecies.jl
@@ -139,9 +139,24 @@ end
 
 ChemicalSpecies(sym::ChemicalSpecies) = sym
 
-==(a::ChemicalSpecies, sym::Symbol) = 
-        ((a == ChemicalSpecies(sym)) && (Symbol(a) == sym))
+function ==(a::ChemicalSpecies, sym::Symbol)
+    # We need to catch ArgumentError here as e.g.
+    # ChemicalSpecies(:H) == :not_atom
+    # does throw an error but should return false
+    local tmp
+    try 
+        tmp = ChemicalSpecies(sym)
+    catch e
+        if e isa ArgumentError
+            return false
+        else
+            rethrow()
+        end
+    end
+    return (a == tmp) && (Symbol(a) == sym)
+end
 
+==(sym::Symbol, a::ChemicalSpecies) = ==(a, sym)
 
 function ==(cs1::ChemicalSpecies, cs2::ChemicalSpecies)
     if cs1.atomic_number != cs2.atomic_number

--- a/src/utils/chemspecies.jl
+++ b/src/utils/chemspecies.jl
@@ -143,9 +143,8 @@ function ==(a::ChemicalSpecies, sym::Symbol)
     # We need to catch ArgumentError here as e.g.
     # ChemicalSpecies(:H) == :not_atom
     # does throw an error but should return false
-    local tmp
-    try 
-        tmp = ChemicalSpecies(sym)
+    tmp = try
+        ChemicalSpecies(sym)
     catch e
         if e isa ArgumentError
             return false

--- a/test/species.jl
+++ b/test/species.jl
@@ -36,6 +36,15 @@ end
 @test ChemicalSpecies(:U238) == :U238
 @test ChemicalSpecies(:Cl35) == :Cl35
 @test ChemicalSpecies(:He3) == :He3
+@test ChemicalSpecies(:H) != :not_atom
+@test :H == ChemicalSpecies(:H)
+@test :D == ChemicalSpecies(:D)
+@test :T == ChemicalSpecies(:T)
+@test :X == ChemicalSpecies(:X)
+@test :Fe56 == ChemicalSpecies(:Fe56)
+@test :Al27 == ChemicalSpecies(:Al27)
+@test :He4 == ChemicalSpecies(:He4)
+@test :not_atom != ChemicalSpecies(:O)
 
 @test_throws ArgumentError ChemicalSpecies(:C; atom_name=:MyLongC)
 @test_throws ArgumentError ChemicalSpecies(:U2389)
@@ -66,6 +75,7 @@ end
 
 tmp = ChemicalSpecies(:C12; atom_name=:MyC)
 @test atom_name(tmp) != atomic_symbol(tmp)
+@test atomic_symbol(tmp) != atom_name(tmp)
 
 @test mass(ChemicalSpecies(:C)) != mass(ChemicalSpecies(:C12))
 @test mass(ChemicalSpecies(:C12)) != mass(ChemicalSpecies(:C13))


### PR DESCRIPTION
The issue had a little more complicated that what it looked like. There was another bug that triggered when when trying direct fix.

So. this fixes the original issue

```julia
julia> ChemicalSpecies(:Si) == :Si
true

julia> :Si == ChemicalSpecies(:Si) # now fixed
true
```

and the other issue that was

```julia
julia> ChemicalSpecies(:H) == :not_atom
ArgumentError
```

and now is

```julia
julia> ChemicalSpecies(:H) == :not_atom
false
```

For the record the latter was triggered by

```julia
tmp = ChemicalSpecies(:C12; atom_name=:MyC)
@test atom_name(tmp) != atomic_symbol(tmp)
```

which raised an error for `ChemicalSpecies(:MyC)`.

Because this is a bigger fix this needs some reviews too.